### PR TITLE
Update timestamp and timerange types to use string patterns

### DIFF
--- a/api/TimeAddressableMediaStore.yaml
+++ b/api/TimeAddressableMediaStore.yaml
@@ -657,7 +657,7 @@ paths:
             X-Paging-Next-Timerange:
               description: The 'timerange' to use in the Post data to get the next page. If 'X-Paging-Next-Timerange' is not present then it is the last page.
               schema:
-                type: integer
+                $ref: '#/components/schemas/timerange_type'
             X-Paging-Limit:
               description: Identifies the current limit being used for paging. This may not match the requested value if the requested value was too high for the implementation.
               schema:

--- a/api/schemas/flow-segment.json
+++ b/api/schemas/flow-segment.json
@@ -26,27 +26,27 @@
     "ts_offset": {
       "description": "The timestamp offset between the timestamps stored in the media file and the corresponding timestamp in the segment, ie. ts_offset = segment ts - media object ts.",
       "type": "string",
-      "format": "timeoffset"
+      "pattern": "^-?\\d+:\\d+$"
     },
     "range": {
-      "description": "The timerange from the first media unit in the segment to the last (exclusive if exclusive_last_ts is true).",
+      "description": "The timerange from the first media unit in the segment to the last (exclusive end if exclusive_last_ts is true).",
       "type": "string",
-      "format": "inclusive_start_timerange"
+      "pattern": "^(\\[)?-?\\d+:\\d+(_-?\\d+:\\d+)?(\\]|\\))?$"
     },
     "first_ts" : {
       "description": "The timestamp of the first media unit in the segment (not media file).",
       "type": "string",
-      "format": "timestamp"
+      "pattern": "^-?\\d+:\\d+$"
     },
     "last_duration": {
       "description": "The duration of the last media unit in the segment (not media file). Defaults to 1/rate if a fixed media rate is set.",
       "type": "string",
-      "format": "timeoffset"
+      "pattern": "^\\d+:\\d+$"
     },
     "last_ts" : {
       "description": "The timestamp of the last media unit or end of the last media unit if exclusive_last_ts is true.",
       "type": "string",
-      "format": "timestamp"
+      "pattern": "^-?\\d+:\\d+$"
     },
     "exclusive_last_ts" : {
       "description": "A true value indicates that the last_ts timestamp is the exclusive end of the last media unit in the segment.",

--- a/api/schemas/flow-storage-post.json
+++ b/api/schemas/flow-storage-post.json
@@ -6,7 +6,7 @@
         "timerange": {
             "description": "Limit the target timerange for the storage segments",
             "type": "string",
-            "pattern": "[\\[\\(]\\d*:\\d*_\\d*:\\d*[\\]\\)]"
+            "pattern": "^(\\[|\\()?-?\\d+:\\d+?(_(-?\\d+:\\d+)?)?(\\]|\\))?$"
         },
         "limit": {
             "description": "Limit the number of storage segments in each response page. Implementations may specify their own default and maximum for the limit",


### PR DESCRIPTION
# Details
This PR changes the timestamp and timerange types in the JSON schemas to use `pattern` rather than a descriptive-only `format`. This PR also fixes the `X-Paging-Next-Timerange` header value type and expands the timerange that can be POSTed to the `/storage` endpoint.

# Pivotal Story
Story URL: https://www.pivotaltracker.com/story/show/186122009

# Related PRs
_Where appropriate. Indicate order to be merged._

# Links to external test runs/working deployment
_Where appropriate, if separate to default CI run_

# Submitter PR Checks
_(tick as appropriate)_

- [x] Added bbc/rd-apmm-cloudfit team as a reviewer
- [x] PR completes task/fixes bug
- [ ] Tests exercise code appropriately
- [ ] New features and API breaks are flagged in commit messages using magic strings
- [ ] Repo maintainer is notified that a release is required
- [ ] Documentation updated (README, Confluence, Docstrings, API spec, Engineering Guide, etc.)
- [ ] Downstream repos have been checked for potential breaks & fixed as needed
- [ ] APIs/UIs/CLIs updated as required
- [x] PR added to Pivotal story
- [ ] Follow-up stories added to Pivotal
- [ ] Any temporary code/configuration removed (e.g. test deployment environment, temporary commontooling branch)
- [ ] Any pins against pre-releases have been removed

# Reviewer PR Checks
_(tick as appropriate)_

- [ ] PR completes task/fixes bug
- [ ] Tests exercise code appropriately
- [ ] Design makes sense, and fits with our current code base
- [ ] Code is easy to follow
- [ ] PR size is sensible
- [ ] Commit history is sensible and tidy

# Info on Cloudfit PRs
- The checks above are guidelines. They don't all have to be ticked, but they should all have been considered.
- For more details on how to asses PRs, see: https://github.com/bbc/rd-apmm-docs-ways-of-working/blob/master/workflow/PRChecklist.md
