### PR TITLE
Describe flow segment timing adjustments when GETting

### DIFF
--- a/api/TimeAddressableMediaStore.yaml
+++ b/api/TimeAddressableMediaStore.yaml
@@ -514,7 +514,7 @@ paths:
 
         The flow segment may include timing and range adjustment information that the client needs to
         apply when extracting the samples from the media object.
-        - The range of samples must be limited to `sample_offset` to `sample_offset + sample_count`
+        - The range of samples must be limited to the range from `sample_offset` to `sample_offset + sample_count`
           (exclusive) if `sample_count` is set, or from `sample_offset` until the end if `sample_count`
           is not set.
         - The sample timestamp in the flow segment (`segment_ts`) is the timestamp in the media object

--- a/api/TimeAddressableMediaStore.yaml
+++ b/api/TimeAddressableMediaStore.yaml
@@ -518,7 +518,7 @@ paths:
           (exclusive) if `sample_count` is set, or from `sample_offset` until the end if `sample_count`
           is not set.
         - The sample timestamp in the flow segment (`segment_ts`) is the timestamp in the media object
-          (`media_unit_ts`) adjusted by `ts_offset`: `segment_ts = media_unit_ts + ts_offset`. The
+          (`media_object_ts`) adjusted by `ts_offset`: `segment_ts = media_object_ts + ts_offset`. The
           `segment_ts` should equal the `first_ts` for the sample at `sample_offset`.
 
         Use the pagination options to limit the results to a time range and/or count. The list of flow
@@ -591,11 +591,11 @@ paths:
 
         For newly-written objects, the client is responsible for ensuring that the segment written to the store obeys the following restrictions:
         - The object id provided for a segment MUST be one which was received in a POST from /storage for this flow.
-        - The timestamp of the first media unit written to the object MUST be located inside the time range
+        - The timestamp of the first sample written to the object MUST be located inside the time range
           that was associated with this object id in the response from the POST request to /storage for this flow.
-        - All media units in the object SHOULD be used by the segment.
-        - The timestamps of each media unit in the file MUST equal its position on the Flow timeline, OR `ts_offset` MUST
-          be set such that `media_unit_ts + ts_offset = segment_ts`
+        - All samples in the object SHOULD be used by the segment.
+        - The timestamps of each sample in the media object MUST equal its position on the Flow timeline, OR `ts_offset` MUST
+          be set such that `media_object_ts + ts_offset = segment_ts`
         - The `sample_offset` SHOULD be zero.
 
         For objects that have been re-used from other flows, the `sample_offset` and `sample_count` MAY be used to

--- a/api/TimeAddressableMediaStore.yaml
+++ b/api/TimeAddressableMediaStore.yaml
@@ -506,10 +506,20 @@ paths:
       description: |
         Returns the flow segments.
 
-        The media store type, which is indicated in the /service resource, determines the information that
-        is provided in the response for downloading the flow segment's media object. The examples provided
-        here are for the "http_object_store" media store type. The flow segment includes a "get_url"
-        property which contains a HTTP URL for downloading the media object.
+        The flow segment provides information about the media object. The media store type, which is
+        indicated in the /service resource, determines the information that is included to allow the
+        flow segment's media object to be downloaded. The examples provided here are for the
+        "http_object_store" media store type which will include a "get_url" property that contains a
+        HTTP URL for downloading the media object.
+
+        The flow segment may include timing and range adjustment information that the client needs to
+        apply when extracting the samples from the media object.
+        - The range of samples must be limited to `sample_offset` to `sample_offset + sample_count`
+          (exclusive) if `sample_count` is set, or from `sample_offset` until the end if `sample_count`
+          is not set.
+        - The sample timestamp in the flow segment (`segment_ts`) is the timestamp in the media object
+          (`media_unit_ts`) adjusted by `ts_offset`: `segment_ts = media_unit_ts + ts_offset`. The
+          `segment_ts` should equal the `first_ts` for the sample at `sample_offset`.
 
         Use the pagination options to limit the results to a time range and/or count. The list of flow
         segments can be empty. A request for segments from a non-existent flow will return an empty

--- a/api/schemas/flow-segment.json
+++ b/api/schemas/flow-segment.json
@@ -24,37 +24,37 @@
       "type": "string"
     },
     "ts_offset": {
-      "description": "The timestamp offset between the timestamps stored in the media file and the corresponding timestamp in the segment, ie. ts_offset = segment ts - media object ts. Assumed to be 0:0 if not set. Format as described by the [Timestamp](../schemas/timestamp#top) type, but cannot be negative",
+      "description": "The timestamp offset between the sample timestamps stored in the media file and the corresponding timestamp in the segment, ie. ts_offset = segment ts - media object ts. Assumed to be 0:0 if not set. Format as described by the [Timestamp](../schemas/timestamp#top) type, but cannot be negative",
       "$ref": "timestamp.json"
     },
     "range": {
-      "description": "The timerange from the first media unit in the segment to the last (exclusive end if exclusive_last_ts is true), as described by the [TimeRange](../schemas/timerange#top) type",
+      "description": "The timerange from the first sample in the segment to the last (exclusive end if exclusive_last_ts is true), as described by the [TimeRange](../schemas/timerange#top) type",
       "$ref": "timerange.json"
     },
     "first_ts" : {
-      "description": "The timestamp of the first media unit in the segment (which may not be the first unit in the object). Format as described by the [Timestamp](../schemas/timestamp#top) type",
+      "description": "The timestamp of the first sample in the segment (which may not be the first sample in the object). Format as described by the [Timestamp](../schemas/timestamp#top) type",
       "$ref": "timestamp.json"
     },
     "last_duration": {
-      "description": "The duration of the last media unit in the segment (which may differ from that of the object). Defaults to 1/rate if a fixed media rate is set. Format as described by the [Timestamp](../schemas/timestamp#top) type, but cannot be negative",
+      "description": "The duration of the last sample in the segment (which may differ from that of the object). Defaults to 1/rate if a fixed media rate is set. Format as described by the [Timestamp](../schemas/timestamp#top) type, but cannot be negative",
       "$ref": "timestamp.json"
     },
     "last_ts" : {
-      "description": "The timestamp of the start of the last media unit in the segment, or end of the last media unit in the segment if exclusive_last_ts is true. Format as described by the [Timestamp](../schemas/timestamp#top) type",
+      "description": "The timestamp of the start of the last sample in the segment, or end of the last sample in the segment if exclusive_last_ts is true. Format as described by the [Timestamp](../schemas/timestamp#top) type",
       "$ref": "timestamp.json"
     },
     "exclusive_last_ts" : {
-      "description": "A true value indicates that the last_ts timestamp is the exclusive end of the last media unit in the segment.",
+      "description": "A true value indicates that the last_ts timestamp is the exclusive end of the last sample in the segment.",
       "type": "boolean",
       "default": false
     },
     "sample_offset": {
-      "description": "The start of the segment represented as a count of audio samples, video frames or data items from the start of the object.",
+      "description": "The start of the segment represented as a count of samples from the start of the object.",
       "type": "integer",
       "default": 0
     },
     "sample_count": {
-      "description": "The count of media units in the segment (which may be fewer than in the object). The count could be less than expected given the segment duration and rate if there are gaps. If not set, every sample from sample_offset onwards is used",
+      "description": "The count of samples in the segment (which may be fewer than in the object). The count could be less than expected given the segment duration and rate if there are gaps. If not set, every sample from sample_offset onwards is used",
       "type": "integer"
     },
     "get_url": {


### PR DESCRIPTION
# Details
This PR adds an explanation to `/segments` GET for timing and range adjustments. It also includes a naming consistency change to use `sample` rather than `media_unit` for audio samples, video frames or data units. This also better aligns it with the property names.

# Pivotal Story
Story URL: https://www.pivotaltracker.com/story/show/186711089

# Related PRs
_Where appropriate. Indicate order to be merged._

# Links to external test runs/working deployment
_Where appropriate, if separate to default CI run_

# Submitter PR Checks
_(tick as appropriate)_

- [ ] Added bbc/rd-apmm-cloudfit team as a reviewer
- [ ] PR completes task/fixes bug
- [ ] Tests exercise code appropriately
- [ ] New features and API breaks are flagged in commit messages using magic strings
- [ ] Repo maintainer is notified that a release is required
- [ ] Documentation updated (README, Confluence, Docstrings, API spec, Engineering Guide, etc.)
- [ ] Downstream repos have been checked for potential breaks & fixed as needed
- [ ] APIs/UIs/CLIs updated as required
- [ ] PR added to Pivotal story
- [ ] Follow-up stories added to Pivotal
- [ ] Any temporary code/configuration removed (e.g. test deployment environment, temporary commontooling branch)
- [ ] Any pins against pre-releases have been removed

# Reviewer PR Checks
_(tick as appropriate)_

- [ ] PR completes task/fixes bug
- [ ] Tests exercise code appropriately
- [ ] Design makes sense, and fits with our current code base
- [ ] Code is easy to follow
- [ ] PR size is sensible
- [ ] Commit history is sensible and tidy

# Info on Cloudfit PRs
- The checks above are guidelines. They don't all have to be ticked, but they should all have been considered.
- For more details on how to asses PRs, see: https://github.com/bbc/rd-apmm-docs-ways-of-working/blob/master/workflow/PRChecklist.md
