### PR TITLE
Indicate that timestamps are managed by the API server and ignored on PUT

### DIFF
--- a/api/schemas/flow-core.json
+++ b/api/schemas/flow-core.json
@@ -47,17 +47,17 @@
       "type": "integer"
     },
     "created": {
-      "description": "The date-time the flow was created in a given context, e.g. in a store",
+      "description": "The date-time the flow was created in a given context, e.g. in a store. Implementations SHOULD ignore this if given in a PUT request, and instead manage it internally",
       "type": "string",
       "format": "date-time"
     },
     "metadata_updated": {
-      "description": "The date-time the flow metadata was updated in a given context, e.g. in a store",
+      "description": "The date-time the flow metadata was updated in a given context, e.g. in a store. Implementations SHOULD ignore this if given in a PUT request, and instead manage it internally",
       "type": "string",
       "format": "date-time"
     },
     "segments_updated": {
-      "description": "The date-time the flow segments were updated in a given context, e.g. in a store",
+      "description": "The date-time the flow segments were updated in a given context, e.g. in a store. Implementations SHOULD ignore this if given in a PUT request, and instead manage it internally",
       "type": "string",
       "format": "date-time"
     },

--- a/api/schemas/flow-core.json
+++ b/api/schemas/flow-core.json
@@ -47,17 +47,17 @@
       "type": "integer"
     },
     "created": {
-      "description": "The date-time the flow was created in a given context, e.g. in a store. Implementations SHOULD ignore this if given in a PUT request, and instead manage it internally",
+      "description": "The date-time the flow was created in a given context, e.g. in the store. Implementations SHOULD ignore this if given in a PUT request, and instead manage it internally",
       "type": "string",
       "format": "date-time"
     },
     "metadata_updated": {
-      "description": "The date-time the flow metadata was updated in a given context, e.g. in a store. Implementations SHOULD ignore this if given in a PUT request, and instead manage it internally",
+      "description": "The date-time the flow metadata was updated in a given context, e.g. in the store. Implementations SHOULD ignore this if given in a PUT request, and instead manage it internally",
       "type": "string",
       "format": "date-time"
     },
     "segments_updated": {
-      "description": "The date-time the flow segments were updated in a given context, e.g. in a store. Implementations SHOULD ignore this if given in a PUT request, and instead manage it internally",
+      "description": "The date-time the flow segments were updated in a given context, e.g. in the store. Implementations SHOULD ignore this if given in a PUT request, and instead manage it internally",
       "type": "string",
       "format": "date-time"
     },

--- a/api/schemas/source.json
+++ b/api/schemas/source.json
@@ -40,12 +40,12 @@
             "type": "string"
         },
         "created": {
-            "description": "The date-time the Source was created in a given context, e.g. in a store",
+            "description": "The date-time the Source was created in a given context, e.g. in a store. Implementations SHOULD ignore this if given in a PUT request, and instead manage it internally",
             "type": "string",
             "format": "date-time"
         },
         "updated": {
-            "description": "The date-time the Source metadata was last updated in a given context, e.g. in a store",
+            "description": "The date-time the Source metadata was last updated in a given context, e.g. in a store. Implementations SHOULD ignore this if given in a PUT request, and instead manage it internally",
             "type": "string",
             "format": "date-time"
         },

--- a/api/schemas/source.json
+++ b/api/schemas/source.json
@@ -40,12 +40,12 @@
             "type": "string"
         },
         "created": {
-            "description": "The date-time the Source was created in a given context, e.g. in a store. Implementations SHOULD ignore this if given in a PUT request, and instead manage it internally",
+            "description": "The date-time the Source was created in a given context, e.g. in the store. Implementations SHOULD ignore this if given in a PUT request, and instead manage it internally",
             "type": "string",
             "format": "date-time"
         },
         "updated": {
-            "description": "The date-time the Source metadata was last updated in a given context, e.g. in a store. Implementations SHOULD ignore this if given in a PUT request, and instead manage it internally",
+            "description": "The date-time the Source metadata was last updated in a given context, e.g. in the store. Implementations SHOULD ignore this if given in a PUT request, and instead manage it internally",
             "type": "string",
             "format": "date-time"
         },

--- a/docs/adr/decisions/0003-item-timestamps-managed-internally.md
+++ b/docs/adr/decisions/0003-item-timestamps-managed-internally.md
@@ -1,0 +1,50 @@
+---
+status: "proposed"
+---
+# Created and Modified Timestamps should be managed internally
+
+## Context and Problem Statement
+
+Flows (and Sources if [ADR 002](./0002-add-sources-to-api.md) is accepted) have fields indicating when they were created and last modified, however the API specification and schemas are not clear on whether these fields can be modified by a client, or whether they are exclusively managed by the server.
+
+See [schemas/flow-core.json](../../../api/schemas/flow-core.json) for definitions of those fields.
+They exist primarily to make it easier to find items of interest in the API and support engineering functions such as application development and debugging.
+
+## Considered Options
+
+* Option 1: Allow clients to change the dates when making a PUT request
+* Option 2: Ignore the date-time values in client requests
+
+## Decision Outcome
+
+Chosen option: Option 2 - Ignore the date-time values in client requests, because it allows users to trust the behaviour of the date-time values, which is important given their primary purpose is to support development and debugging.
+
+This limits the use of the `created` field to refer to when the Flow was originally captured, but that information should ideally live elsewhere in a MAM system, or in the basic case, could be represented using tags.
+
+### Implementation
+
+Implemented by <https://github.com/bbc/tams/pull/19>
+
+## Pros and Cons of the Options
+
+### Option 1: Allow clients to change the dates when making a PUT request
+
+When making a PUT request, e.g. to `PUT /flows/<flowId>` a client should include a value for each of the `created`, `metadata_updated` and `segments_updated` date-time fields.
+The `created` field may correspond to when the Flow was actually created (e.g. the time of capture of the original media) rather than when it was added to the store.
+The `metadata_updated` field must be the current time if the request modifies the metadata, and `segments_updated` should correspond to when the segments were last updated (which may differ from the time currently in the API, if the client knows better.)
+
+* Good, because it allows multiple stores to hold the same Flow and keep the fields in sync
+* Good, because it enables the Flow creation time to be captured, although actual use cases for that are unclear
+* Bad, because the date-time values can no longer be trusted for their original purpose if a client can accidentally modify them
+* Bad, because it creates additional complexity for the client to provide valid values
+* Bad, because it is difficult for the server to validate that values supplied by the client are permissible
+
+### Option 2: Ignore the date-time values in client requests
+
+When making a PUT request, e.g. to `PUT /flows/<flowId>`, values supplied for each of the `created`, `metadata_updated` and `segments_updated` date-time fields are accepted but silently ignored.
+Instead, the server sets the `created` time when the Flow is first created on the API, and decides to update `metadata_updated` and `segments_updated` based on other requests made by clients.
+
+* Good, because the date-time values can be trusted to accurately represent the last time things changed on this particular store
+* Good, because the implementation is fairly simple
+* Bad, because it slightly breaks the expectations of a RESTful PUT, that a resource will be replaced
+* Bad, because if a Flow is copied from another store, the `created` date may not match across stores

--- a/docs/adr/decisions/0003-item-timestamps-managed-internally.md
+++ b/docs/adr/decisions/0003-item-timestamps-managed-internally.md
@@ -1,5 +1,5 @@
 ---
-status: "proposed"
+status: "accepted"
 ---
 # Created and Modified Timestamps should be managed internally
 
@@ -44,3 +44,15 @@ Instead, the server sets the `created` time when the Flow is first created on th
 * Good, because the date-time values can be trusted to accurately represent the last time things changed on this particular store
 * Good, because the implementation is fairly simple
 * Bad, because it slightly breaks the expectations of a RESTful PUT, that a resource will be replaced
+
+## More Information
+
+### TAMS Team Discussion - 12th February 2024
+
+A discussion about this proposal took place on 12th February 2024, with the BBC R&D TAMS team.
+
+There was some discussion as to whether it was OK to have properties that appear in a GET request that cannot be set in a PUT request, and whether that breaks RESTful principles.
+The consensus was that the PUT request is to the Flow resource, and a GET also includes related metadata, in a similar way to how a filesystem will return created and modified attributes.
+In addition, separating the schemas for PUT and GET would make the already complex Flow schema even more cumbersome.
+
+A minor wording change was proposed and accepted, and the consensus was to accept Option 2 of this proposal.

--- a/docs/adr/decisions/0003-item-timestamps-managed-internally.md
+++ b/docs/adr/decisions/0003-item-timestamps-managed-internally.md
@@ -19,8 +19,6 @@ They exist primarily to make it easier to find items of interest in the API and 
 
 Chosen option: Option 2 - Ignore the date-time values in client requests, because it allows users to trust the behaviour of the date-time values, which is important given their primary purpose is to support development and debugging.
 
-This limits the use of the `created` field to refer to when the Flow was originally captured, but that information should ideally live elsewhere in a MAM system, or in the basic case, could be represented using tags.
-
 ### Implementation
 
 Implemented by <https://github.com/bbc/tams/pull/19>
@@ -30,11 +28,10 @@ Implemented by <https://github.com/bbc/tams/pull/19>
 ### Option 1: Allow clients to change the dates when making a PUT request
 
 When making a PUT request, e.g. to `PUT /flows/<flowId>` a client should include a value for each of the `created`, `metadata_updated` and `segments_updated` date-time fields.
-The `created` field may correspond to when the Flow was actually created (e.g. the time of capture of the original media) rather than when it was added to the store.
+The `created` field may correspond to something other than when the Flow was created in this store, for example if it was copied from elsewhere.
 The `metadata_updated` field must be the current time if the request modifies the metadata, and `segments_updated` should correspond to when the segments were last updated (which may differ from the time currently in the API, if the client knows better.)
 
 * Good, because it allows multiple stores to hold the same Flow and keep the fields in sync
-* Good, because it enables the Flow creation time to be captured, although actual use cases for that are unclear
 * Bad, because the date-time values can no longer be trusted for their original purpose if a client can accidentally modify them
 * Bad, because it creates additional complexity for the client to provide valid values
 * Bad, because it is difficult for the server to validate that values supplied by the client are permissible
@@ -47,4 +44,3 @@ Instead, the server sets the `created` time when the Flow is first created on th
 * Good, because the date-time values can be trusted to accurately represent the last time things changed on this particular store
 * Good, because the implementation is fairly simple
 * Bad, because it slightly breaks the expectations of a RESTful PUT, that a resource will be replaced
-* Bad, because if a Flow is copied from another store, the `created` date may not match across stores


### PR DESCRIPTION
# Details
- Adds an ADR proposal describing that the `created` and various `updated` fields are ignored on PUT
- Adds corresponding wording to the field definitions

# Pivotal Story (if relevant)
Story URL: Came up while doing https://www.pivotaltracker.com/story/show/186711160

# Related PRs
Merge after https://github.com/bbc/tams/pull/18

# Submitter PR Checks
_(tick as appropriate)_

- [x] Added bbc/rd-apmm-cloudfit team as a reviewer
- [X] PR completes task/fixes bug
- [X] API version has been incremented if necessary
- [x] ADR status has been updated, and ADR implementation has been recorded
- [X] Documentation updated (README, etc.)
- [X] PR added to Pivotal story (if relevant)
- [ ] Follow-up stories added to Pivotal

# Reviewer PR Checks
_(tick as appropriate)_

- [ ] PR completes task/fixes bug
- [ ] Design makes sense, and fits with our current code base
- [ ] Code is easy to follow
- [ ] PR size is sensible
- [ ] Commit history is sensible and tidy

# Info on PRs
The checks above are guidelines. They don't all have to be ticked, but they should all have been considered.
