### PR TITLE
Add release tooling

### DIFF
--- a/.github/workflows/ci-workflow.yml
+++ b/.github/workflows/ci-workflow.yml
@@ -26,7 +26,7 @@ jobs:
       shouldUpload: ${{ steps.shouldUpload.outputs.upload }}
     steps:
       - name: Check out repository code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0 # check out the entire repo history for SHA verification in lastSuccessful step
 
@@ -63,11 +63,11 @@ jobs:
 
       - name: Setup pages
         if: ${{ inputs.forceDocsUpload || ( steps.shouldUpload.outputs.upload == 'true' ) }}
-        uses: actions/configure-pages@v3
+        uses: actions/configure-pages@v4
 
       - name: Upload documentation artifact
         if: ${{ inputs.forceDocsUpload || ( steps.shouldUpload.outputs.upload == 'true' ) }}
-        uses: actions/upload-pages-artifact@v2
+        uses: actions/upload-pages-artifact@v3
         with:
           path: './api/docs'
 
@@ -84,7 +84,7 @@ jobs:
     steps:
       - name: Deploy documentation to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v2
+        uses: actions/deploy-pages@v4
       - name: Adding summary
         run: |
           echo "Documentation URL: ${{ steps.deployment.outputs.page_url }}" >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/commit-check-workflow.yml
+++ b/.github/workflows/commit-check-workflow.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - name: Check out PR code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           fetch-depth: ${{github.event.pull_request.commits}} # only checkout commits from this PR
           ref: ${{ github.ref }}

--- a/.github/workflows/release-workflow.yml
+++ b/.github/workflows/release-workflow.yml
@@ -1,0 +1,66 @@
+name: Release Workflow
+run-name: ${{ format('{0} triggered {1} on {2}', (github.event_name == 'workflow_dispatch' && format('User {0}', github.actor) || format('{0} event', github.event_name) ), github.workflow, github.ref) }}
+on:
+  workflow_dispatch:
+
+jobs:
+  Release:
+    permissions:
+      contents: write
+    runs-on: ubuntu-22.04
+    environment:
+      name: releases
+      url: ${{ steps.release.outputs.url }}
+    outputs:
+      releaseRef: refs/tags/${{ steps.nextVersion.outputs.version }}
+    steps:
+      - name: Check out repository code
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0 # check out entire repo for version calculation
+
+      - name: Get next version number
+        id: nextVersion
+        run: echo "version=$(make next-version)" >> $GITHUB_OUTPUT
+
+      - name: Update version in OpenAPI document
+        run: make update-api-version
+
+      # NOTE: `git tag` will fail if the version hasn't moved and the changes (if any) won't be committed. The release job will also fail
+      - name: Commit changes and create tag
+        id: commit
+        run: |
+          git config --global user.email "cloudfit-opensource@rd.bbc.co.uk"
+          git config --global user.name "BBC RD"
+          git add api/TimeAddressableMediaStore.yaml
+          git commit -m "Bump version"
+          git tag -a ${{ steps.nextVersion.outputs.version }} -m "v.${{ steps.nextVersion.outputs.version }}"
+          git push origin --tags :
+
+      - name: Create release
+        id: release
+        uses: actions/github-script@v7
+        with:
+          github-token: "${{ secrets.GITHUB_TOKEN }}"
+          script: |
+            try {
+              const response = await github.rest.repos.createRelease({
+                generate_release_notes: true,
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                tag_name: '${{ steps.nextVersion.outputs.version }}'
+              });
+
+              core.setOutput('url', response.data.html_url);
+            } catch (error) {
+              core.setFailed(error.message);
+            }
+
+      - name: Adding summary
+        run: |
+          echo "Release Version: ${{ steps.nextVersion.outputs.version }}" >> $GITHUB_STEP_SUMMARY
+          echo "Release URL: ${{ steps.release.outputs.url }}" >> $GITHUB_STEP_SUMMARY
+
+      - name: Report errors
+        if: ${{ always() && (steps.commit.outcome != 'success') }}
+        run: echo "::error title=Nothing to release::No changes that will trigger a version bump. You may need to set an appropriate sem-ver magic string in a commit message."

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -15,7 +15,12 @@ The process is:
 
 1. Fork the repository
 2. For more significant changes, consider starting with writing an ADR document: see [the ADR readme](./docs/adr/decisions/README.md) for more
-3. Make, commit and push changes to a branch on your fork (make sure the commit message contains your email address)
+3. Make, commit and push changes to a branch on your fork
+   - Make sure the commit message contains your email address
+   - Where appropriate, make sure your commit messages includes a line with one of the following:
+      - `sem-ver: api-break` - where a breaking change is made
+      - `sem-ver: feature` - where a new feature has been added
+      - `sem-ver: deprecation` - where an existing feature has been marked as deprecated, but not yet removed
 4. If you haven't already done so, sign the CLA (see below)
 5. Open a Pull Request with your changes.
    Don't worry about leaving empty spaces on the PR template (it's aimed at internal contributions), just fill in the description

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,9 @@
 NUM_OF_PARENT:=$(shell echo $$(( $(words $(MAKEFILE_LIST)))) )
 topdir:=$(realpath $(dir $(word $(NUM_OF_PARENT),$(MAKEFILE_LIST))))
 
+# pbrversion calculates versions based on git tags, number of commits since the most recent tag, magic strings in commit messages to signal types of changes. Magic strings are of the form `Sem-Ver: ` followed by one of `feature`, `api-break`, `deprecation`, and `bugfix`. pbrversion returns a `<major>.<minor>.<patch>` semantic version. This repo only uses a `<major>.<minor>` version, so the last component is stripped using make's `basename` function.
+NEXT_VERSION := $(basename $(shell docker run --rm -v $(topdir):/data:ro public.ecr.aws/o4o2s1w1/cloudfit/pbrversion:1.4.1 --brief))
+
 all: help
 
 render:
@@ -20,11 +23,19 @@ lint-apispec:
 
 lint: lint-markdown lint-apispec
 
+next-version:
+	@echo $(NEXT_VERSION)
+
+update-api-version:
+	docker run --user="root" --rm -v "$(topdir)/api":/workdir mikefarah/yq e ".info.version = \"$(NEXT_VERSION)\" | .servers[1].variables.version.default = \"v$(NEXT_VERSION)\"" -i TimeAddressableMediaStore.yaml
+
 help:
 	@echo "tams-api"
-	@echo "make render           - Generate HTML rendered version of OpenAPI document"
-	@echo "make mock-server-up   - Start a mock API server on http://localhost:4010"
-	@echo "make mock-server-down - Stop the mock API server"
-	@echo "make lint             - Lint API specification document and Markdown files"
+	@echo "make render             - Generate HTML rendered version of OpenAPI document"
+	@echo "make mock-server-up     - Start a mock API server on http://localhost:4010"
+	@echo "make mock-server-down   - Stop the mock API server"
+	@echo "make lint               - Lint API specification document and Markdown files"
+	@echo "make next-version       - Print the version the code should have if it is released as it currently is"
+	@echo "make update-api-version - Update the API version in the OpenAPI document to match the next-version. This WILL NOT make a release on the repository."
 
-.PHONY: help render mock-server-up mock-server-down
+.PHONY: help render mock-server-up mock-server-down lint-markdown lint-apispec lint next-version update-api-version

--- a/README.md
+++ b/README.md
@@ -92,15 +92,33 @@ Various scenarios are explored in the [Practical Guidance for Media](https://spe
 ### API Versioning
 
 The API is versioned using a major and minor version number.
-A breaking change results in a major version increment and the minor version is reset to 0.
+A breaking change - such as removal of a feature, or renaming of properties in such a way that would break compatibility (including fixing a typo) - results in a major version increment and the minor version is reset to 0.
 Features such new endpoints or new (optional) data properties result in a minor version increment.
-Other changes such as bug fixes and documentation changes do not result in version updates.
+Other changes such as documentation changes do not result in version updates.
 Note that the version may change frequently whilst the API is still under development!
+
+Versions are calculated automatically upon release using 'magic' strings included in commit messages:
+    - `sem-ver: api-break` - where a breaking change is made (results in a major version bump)
+    - `sem-ver: feature` - where a new feature has been added (results in a minor version bump)
+    - `sem-ver: deprecation` - where an existing feature has been marked as deprecated, but not yet removed (results in a minor version bump)
+Commits without one of these magic strings are assumed to be unsubstantial and will not result in a version bump.
+Versions will only be incremented once when a release is made.
+If there are multiple commits since the last release, the major version number will be incremented by 1, and minor version set to 0 if at least one of the commits contains an `api-break`.
+If there are no `api-break` changes since the last release, the minor version will be incremented by 1 if at least one commit contains a `feature` or `deprecation` change.
+Otherwise, the version will not change.
+
+It is possible to see what the version would be if a release was made at the current commit by running `make next-version` in the top directory of this repository.
 
 ## Proposals, Decisions and Architecture Changes
 
 This repository uses [(M)ADR documents](https://adr.github.io/madr/) to propose significant changes, facilitate discussions and decision making, and to store a record of options that were considered.
 These documents may be found in the [docs/adr/decisions](./docs/adr/decisions/) directory, and are managed as described by the [ADR Readme](./docs/adr/decisions/README.md).
+
+## Making a release
+
+Run the `release` workflow under the `Actions` tab on this repository on GitHub against the `main` branch.
+This workflow requires approval.
+This workflow will fail if it does not identify any commits that would result in a version bump (see [API Versioning](#api-versioning)).
 
 ## Get in touch
 


### PR DESCRIPTION
# Details
* Adds a GitHub Actions workflow for creating releases
* Adds tooling to the makefile for calculating the version for releases
* Adds tooling to the makefile to update the version in the OpenAPI document
* Adds documentation for how versions are calculated, and how releases are made
* Updates Actions version pins

# Pivotal Story (if relevant)
Story URL: https://www.pivotaltracker.com/story/show/186851593

# Related PRs
_Where appropriate. Indicate order to be merged._

# Submitter PR Checks
_(tick as appropriate)_

- [ ] PR completes task/fixes bug
- [ ] API version has been incremented if necessary
- [ ] ADR status has been updated, and ADR implementation has been recorded
- [ ] Documentation updated (README, etc.)
- [ ] PR added to Pivotal story (if relevant)
- [ ] Follow-up stories added to Pivotal

# Reviewer PR Checks
_(tick as appropriate)_

- [ ] PR completes task/fixes bug
- [ ] Design makes sense, and fits with our current code base
- [ ] Code is easy to follow
- [ ] PR size is sensible
- [ ] Commit history is sensible and tidy

# Info on PRs
The checks above are guidelines. They don't all have to be ticked, but they should all have been considered.
