### PR TITLE
Clarify what a sample is for FlowSegment sample_offset/count

### DIFF
--- a/api/schemas/flow-segment.json
+++ b/api/schemas/flow-segment.json
@@ -24,12 +24,12 @@
       "$ref": "timestamp.json"
     },
     "sample_offset": {
-      "description": "The start of the segment represented as a count of samples from the start of the object.",
+      "description": "The start of the segment represented as a count of samples from the start of the object. Note that a sample is a video frame or audio sample. A (coded) audio frame has multiple audio samples",
       "type": "integer",
       "default": 0
     },
     "sample_count": {
-      "description": "The count of samples in the segment (which may be fewer than in the object). The count could be less than expected given the segment duration and rate if there are gaps. If not set, every sample from sample_offset onwards is used",
+      "description": "The count of samples in the segment (which may be fewer than in the object). The count could be less than expected given the segment duration and rate if there are gaps. If not set, every sample from sample_offset onwards is used. Note that a sample is a video frame or audio sample. A (coded) audio frame has multiple audio samples",
       "type": "integer"
     },
     "get_url": {


### PR DESCRIPTION
# Details
This PR adds some description text to clarify what is meant by a `sample` is in the definition of the FlowSegment `sample_offset` and `sample_count` properties.

Note that there is a general discussion about whether FlowSegment should reference the coded media units or presentation media units. The result of that discussion may be that the definition and naming of these properties changes.

# Pivotal Story (if relevant)
Story URL:

# Related PRs
_Where appropriate. Indicate order to be merged._

# Submitter PR Checks
_(tick as appropriate)_

- [ ] PR completes task/fixes bug
- [ ] API version has been incremented if necessary
- [ ] ADR status has been updated, and ADR implementation has been recorded
- [ ] Documentation updated (README, etc.)
- [ ] PR added to Pivotal story (if relevant)
- [ ] Follow-up stories added to Pivotal

# Reviewer PR Checks
_(tick as appropriate)_

- [ ] PR completes task/fixes bug
- [ ] Design makes sense, and fits with our current code base
- [ ] Code is easy to follow
- [ ] PR size is sensible
- [ ] Commit history is sensible and tidy

# Info on PRs
The checks above are guidelines. They don't all have to be ticked, but they should all have been considered.
