### PR TITLE
Clarify expectations of Flow Segment get_url

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ The media data contained within Flow Segments may be stored separately from the 
 For example our implementation uses a database (_e.g._ Amazon DynamoDB) to store Flow Segment metadata and an object store (_e.g._ AWS S3) to store the media data for Flow Segments.
 We refer to media data stored in the object store as 'media objects'.
 The Flow Segment has a list of S3 download urls which are the location of the media object(s) that contains the stored media data for the Flow Segment.
-If multiple URLs are returned in the list, they are assumed to be identical.
+If multiple URLs are returned in the list, they are assumed to return identical media data.
 When writing to the store, the S3 URLs can be passed to a client permitting them to upload media data directly.
 
 Another advantage of separating the media data and metadata planes in this way is that a particular Flow Segment can be referenced by multiple flows.

--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ If multiple URLs are returned in the list, they are assumed to be identical.
 When writing to the store, the S3 URLs can be passed to a client permitting them to upload media data directly.
 
 Another advantage of separating the media data and metadata planes in this way is that a particular Flow Segment can be referenced by multiple flows.
-On the metadata side, the Flow Segment is just a URL, so any number of flows can record that same URL against other `<flow_id, timestamp>` tuples.
+On the metadata side, the Flow Segment is just an object ID, so any number of flows can record that same ID against other `<flow_id, timestamp>` tuples.
 This allows for copy-on-write semantics: immutability means a new Flow must be created to make changes to existing parts of the timeline, but for unmodified portions of the timeline the new `<flow_id, timestamp>` tuple points to the existing object ID or a part of it.
 See [Flow And Media Timelines](#flow-and-media-timelines) for a description of how that works in practice.
 

--- a/README.md
+++ b/README.md
@@ -54,7 +54,8 @@ The store provides a mechanism to upload and register new Flow Segments, and an 
 The media data contained within Flow Segments may be stored separately from the metadata linking them to a position on the timeline, separating the media data and metadata planes.
 For example our implementation uses a database (_e.g._ Amazon DynamoDB) to store Flow Segment metadata and an object store (_e.g._ AWS S3) to store the media data for Flow Segments.
 We refer to media data stored in the object store as 'media objects'.
-The Flow Segment has a single S3 download url which is the location of the media object that contains the stored media data for the Flow Segment.
+The Flow Segment has a list of S3 download urls which are the location of the media object(s) that contains the stored media data for the Flow Segment.
+If multiple URLs are returned in the list, they are assumed to be identical.
 When writing to the store, the S3 URLs can be passed to a client permitting them to upload media data directly.
 
 Another advantage of separating the media data and metadata planes in this way is that a particular Flow Segment can be referenced by multiple flows.

--- a/api/TimeAddressableMediaStore.yaml
+++ b/api/TimeAddressableMediaStore.yaml
@@ -976,7 +976,7 @@ paths:
                   summary: Multiple URLs
                   description: |
                     This example shows how the media object for a Flow Segment could be accessed using multiple URLs.
-                    Clients are free to choose any of the URLs given (which are all identical), however the server has
+                    Clients are free to choose any of the URLs given (which return identical media objects), however the server has
                     expressed a preference for the "pipeline-a" URLs by putting them first in the list.
                   value:
                     $ref: examples/flow-segments-get-200-multiple-urls.json

--- a/api/TimeAddressableMediaStore.yaml
+++ b/api/TimeAddressableMediaStore.yaml
@@ -889,7 +889,7 @@ paths:
         The flow segment provides information about the media object. The media store type, which is
         indicated in the /service resource, determines the information that is included to allow the
         flow segment's media object to be downloaded. The examples provided here are for the
-        "http_object_store" media store type which will include a "get_url" property that contains a
+        "http_object_store" media store type which MUST include a "get_url" property that contains a
         HTTP URL for downloading the media object.
 
         The flow segment may include timing and timerange adjustment information that the client needs to

--- a/api/TimeAddressableMediaStore.yaml
+++ b/api/TimeAddressableMediaStore.yaml
@@ -889,8 +889,8 @@ paths:
         The flow segment provides information about the media object. The media store type, which is
         indicated in the /service resource, determines the information that is included to allow the
         flow segment's media object to be downloaded. The examples provided here are for the
-        "http_object_store" media store type which MUST include a "get_url" property that contains a
-        HTTP URL for downloading the media object.
+        "http_object_store" media store type which MUST include a `get_urls` property that contains the
+        HTTP URLs for downloading the media object - server implementations should generate this internally.
 
         The flow segment may include timing and timerange adjustment information that the client needs to
         apply when extracting the samples from the media object.
@@ -910,7 +910,7 @@ paths:
         from the start of the requested timerange to retrieve enough reference material to start
         decoding.
 
-        When making requests to the provided `get_url`, clients should include credentials if the provided
+        When making requests to the provided `get_urls`, clients should include credentials if the provided
         URL is on the same origin as the API itself, akin to the `same-origin` mode in the
         [WhatWG Fetch Standard](https://fetch.spec.whatwg.org/#concept-request-credentials-mode).
       operationId: GET_flows-flowId-segments
@@ -972,6 +972,14 @@ paths:
                     subset of the samples within using `ts_offset` for the second segment in the sequence.
                   value:
                     $ref: examples/flow-segments-get-200-sample-offset.json
+                multiple_urls:
+                  summary: Multiple URLs
+                  description: |
+                    This example shows how the media object for a Flow Segment could be accessed using multiple URLs.
+                    Clients are free to choose any of the URLs given (which are all identical), however the server has
+                    expressed a preference for the "pipeline-a" URLs by putting them first in the list.
+                  value:
+                    $ref: examples/flow-segments-get-200-multiple-urls.json
     post:
       description: |
         Register a new flow segment, attaching the object id given to a point in the flow timeline.

--- a/api/TimeAddressableMediaStore.yaml
+++ b/api/TimeAddressableMediaStore.yaml
@@ -909,6 +909,10 @@ paths:
         timeline, and clients may need to check the `key_frame_count` property and/or read backwards
         from the start of the requested timerange to retrieve enough reference material to start
         decoding.
+
+        When making requests to the provided `get_url`, clients should include credentials if the provided
+        URL is on the same origin as the API itself, akin to the `same-origin` mode in the
+        [WhatWG Fetch Standard](https://fetch.spec.whatwg.org/#concept-request-credentials-mode).
       operationId: GET_flows-flowId-segments
       tags:
         - FlowSegments
@@ -1073,6 +1077,10 @@ paths:
         bucket name as its prefix.
 
         The response may include PUT URLs for setting the CORS properties for the buckets and media objects.
+
+        When making requests to the provided `put_url`, clients should include credentials if the provided
+        URL is on the same origin as the API itself, akin to the `same-origin` mode in the
+        [WhatWG Fetch Standard](https://fetch.spec.whatwg.org/#concept-request-credentials-mode).
       operationId: POST_flows-flowId-storage
       tags:
         - MediaStorage

--- a/api/examples/flow-segments-get-200-multiple-urls.json
+++ b/api/examples/flow-segments-get-200-multiple-urls.json
@@ -1,0 +1,50 @@
+[
+  {
+    "object_id": "tams-35e9b447-be10-43e0-ab85-e1e9fe15d354",
+    "timerange": "[100:0_110:0)",
+    "sample_count": 240,
+    "sample_offset": 0,
+    "get_urls": [
+      {
+        "label": "pipeline-a",
+        "url": "https://a4c52e22f45b4a0fa3ea3b9a42b35808-tams-demo.static.lon1.bbcis.uk/e79b3426-f770-4c86-a59e-7a040275bfed"
+      },
+      {
+        "label": "pipeline-b",
+        "url": "https://tams-b.s3.eu-west-1.amazonaws.com/35e9b447-be10-43e0-ab85-e1e9fe15d354?X-Amz-Security-Token=signature..."
+      }
+    ]
+  },
+  {
+    "object_id": "tams-5826312e-9633-4f90-807d-b2588a8ad61f",
+    "timerange": "[110:0_120:0)",
+    "sample_count": 240,
+    "sample_offset": 0,
+    "get_urls": [
+      {
+        "label": "pipeline-a",
+        "url": "https://a4c52e22f45b4a0fa3ea3b9a42b35808-tams-demo.static.lon1.bbcis.uk/9af5e2ff-b28c-4c0f-869b-14ef3fad01d6"
+      },
+      {
+        "label": "pipeline-b",
+        "url": "https://tams-b.s3.eu-west-1.amazonaws.com/5826312e-9633-4f90-807d-b2588a8ad61f?X-Amz-Security-Token=signature..."
+      }
+    ]
+  },
+  {
+    "object_id": "tams-73c8d377-10fb-4c98-9263-6efaf94f3eab",
+    "timerange": "[120:0_130:0)",
+    "sample_count": 240,
+    "sample_offset": 0,
+    "get_urls": [
+      {
+        "label": "pipeline-a",
+        "url": "https://a4c52e22f45b4a0fa3ea3b9a42b35808-tams-demo.static.lon1.bbcis.uk/5bdf042d-c742-4d69-b864-7e9435b2229a"
+      },
+      {
+        "label": "pipeline-b",
+        "url": "https://tams-b.s3.eu-west-1.amazonaws.com/73c8d377-10fb-4c98-9263-6efaf94f3eab?X-Amz-Security-Token=signature..."
+      }
+    ]
+  }
+]

--- a/api/examples/flow-segments-get-200-sample-offset.json
+++ b/api/examples/flow-segments-get-200-sample-offset.json
@@ -4,7 +4,11 @@
     "timerange": "[0:0_10:0)",
     "sample_count": 240,
     "sample_offset": 0,
-    "get_url": "https://a4c52e22f45b4a0fa3ea3b9a42b35808-tams-demo.static.lon1.bbcis.uk/tams-67cd7994-47d4-4e89-9e9f-5e548b7eb7dd.ts",
+    "get_urls": [
+      {
+        "url": "https://a4c52e22f45b4a0fa3ea3b9a42b35808-tams-demo.static.lon1.bbcis.uk/tams-67cd7994-47d4-4e89-9e9f-5e548b7eb7dd.ts"
+      }
+    ],
     "key_frame_count": 10
   },
   {
@@ -13,7 +17,11 @@
     "ts_offset": "5:0",
     "sample_count": 120,
     "sample_offset": 60,
-    "get_url": "https://a4c52e22f45b4a0fa3ea3b9a42b35808-tams-demo.static.lon1.bbcis.uk/tams-7dffa41c-9e12-4e7d-a269-0aae8351d806.ts",
+    "get_urls": [
+      {
+        "url": "https://a4c52e22f45b4a0fa3ea3b9a42b35808-tams-demo.static.lon1.bbcis.uk/tams-7dffa41c-9e12-4e7d-a269-0aae8351d806.ts"
+      }
+    ],
     "key_frame_count": 5
   },
   {
@@ -21,7 +29,11 @@
     "timerange": "[15:0_25:0)",
     "sample_count": 240,
     "sample_offset": 0,
-    "get_url": "https://a4c52e22f45b4a0fa3ea3b9a42b35808-tams-demo.static.lon1.bbcis.uk/tams-bdfb03ae-25a5-4a72-9b9e-14c5119813c9.ts",
+    "get_urls": [
+      {
+        "url": "https://a4c52e22f45b4a0fa3ea3b9a42b35808-tams-demo.static.lon1.bbcis.uk/tams-bdfb03ae-25a5-4a72-9b9e-14c5119813c9.ts"
+      }
+    ],
     "key_frame_count": 10
   }
 ]

--- a/api/examples/flow-segments-get-200.json
+++ b/api/examples/flow-segments-get-200.json
@@ -4,20 +4,32 @@
     "timerange": "[0:0_10:0)",
     "sample_count": 240,
     "sample_offset": 0,
-    "get_url": "https://a4c52e22f45b4a0fa3ea3b9a42b35808-tams-demo.static.lon1.bbcis.uk/tams-67cd7994-47d4-4e89-9e9f-5e548b7eb7dd.ts"
+    "get_urls": [
+      {
+        "url": "https://a4c52e22f45b4a0fa3ea3b9a42b35808-tams-demo.static.lon1.bbcis.uk/tams-67cd7994-47d4-4e89-9e9f-5e548b7eb7dd.ts"
+      }
+    ]
   },
   {
     "object_id": "tams-7dffa41c-9e12-4e7d-a269-0aae8351d806.ts",
     "timerange": "[10:0_20:0)",
     "sample_count": 240,
     "sample_offset": 0,
-    "get_url": "https://a4c52e22f45b4a0fa3ea3b9a42b35808-tams-demo.static.lon1.bbcis.uk/tams-7dffa41c-9e12-4e7d-a269-0aae8351d806.ts"
+    "get_urls": [
+      {
+        "url": "https://a4c52e22f45b4a0fa3ea3b9a42b35808-tams-demo.static.lon1.bbcis.uk/tams-7dffa41c-9e12-4e7d-a269-0aae8351d806.ts"
+      }
+    ]
   },
   {
     "object_id": "tams-bdfb03ae-25a5-4a72-9b9e-14c5119813c9.ts",
     "timerange": "[20:0_30:0)",
     "sample_count": 240,
     "sample_offset": 0,
-    "get_url": "https://a4c52e22f45b4a0fa3ea3b9a42b35808-tams-demo.static.lon1.bbcis.uk/tams-bdfb03ae-25a5-4a72-9b9e-14c5119813c9.ts"
+    "get_urls": [
+      {
+        "url": "https://a4c52e22f45b4a0fa3ea3b9a42b35808-tams-demo.static.lon1.bbcis.uk/tams-bdfb03ae-25a5-4a72-9b9e-14c5119813c9.ts"
+      }
+    ]
   }
 ]

--- a/api/schemas/flow-segment.json
+++ b/api/schemas/flow-segment.json
@@ -32,9 +32,26 @@
       "description": "The count of samples in the segment (which may be fewer than in the object). The count could be less than expected given the segment duration and rate if there are gaps. If not set, every sample from sample_offset onwards is used. Note that a sample is a video frame or audio sample. A (coded) audio frame has multiple audio samples",
       "type": "integer"
     },
-    "get_url": {
-      "description": "A URL to which a GET request can be made to directly retrieve the contents of the segment. This is required by the `http_object_store` media store type, which is the only one currently described. Clients should include credentials if the provide URL is on the same origin as the API endpoint",
-      "type": "string"
+    "get_urls": {
+      "description": "A list of URLs to which a GET request can be made to directly retrieve the contents of the segment. This is required by the `http_object_store` media store type, which is the only one currently described. Clients may choose any URL in the list and treat them as identical, however servers may sort the list such that the preferred URL is first.",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "url"
+        ],
+        "properties": {
+          "label": {
+            "description": "Label identifying this URL",
+            "type": "string"
+          },
+          "url": {
+            "description": "A URL to which a GET request can be made to directly retrieve the contents of the segment. Clients should include credentials if the provide URL is on the same origin as the API endpoint",
+            "type": "string"
+          }
+        },
+        "additionalProperties": false
+      }
     },
     "key_frame_count": {
       "description": "The number of key frames in the segment. This should be set greater than zero when the segment contains key frames that serve as a stream access point",

--- a/api/schemas/flow-segment.json
+++ b/api/schemas/flow-segment.json
@@ -33,7 +33,7 @@
       "type": "integer"
     },
     "get_url": {
-      "description": "A URL to which a GET request can be made to directly retrieve the contents of the segment. This is required by the `http_object_store` media store type, which is the only one currently described",
+      "description": "A URL to which a GET request can be made to directly retrieve the contents of the segment. This is required by the `http_object_store` media store type, which is the only one currently described. Clients should include credentials if the provide URL is on the same origin as the API endpoint",
       "type": "string"
     },
     "key_frame_count": {

--- a/api/schemas/flow-segment.json
+++ b/api/schemas/flow-segment.json
@@ -33,7 +33,7 @@
       "type": "integer"
     },
     "get_url": {
-      "description": "A URL to which a GET request can be made to directly retrieve the contents of the segment. This is optional, and not all media store backends may provide it.",
+      "description": "A URL to which a GET request can be made to directly retrieve the contents of the segment. This is required by the `http_object_store` media store type, which is the only one currently described",
       "type": "string"
     },
     "key_frame_count": {

--- a/docs/adr/decisions/0015-flow-segment-get-url-expectations.md
+++ b/docs/adr/decisions/0015-flow-segment-get-url-expectations.md
@@ -1,0 +1,66 @@
+---
+status: "proposed"
+---
+# Make FlowSegment get_url expectations clearer
+
+## Context and Problem Statement
+
+Currently the API is not specific about how the segment `get_url` should work regarding credentials, and it is optional.
+However in all current practical applications it is required as the only way for a client to retrieve actual media essence, and clients must understand the expectations placed upon them regarding credentials as well.
+
+## Considered Options
+
+Note that in this case, several of these options may be selected.
+
+* Option 1: Make `get_url` mandatory in Flow Segments
+* Option 2: Stipulate that requests to `get_url` should include same-origin credentials
+* Option 3: Make `get_url` a list of `get_urls`
+
+## Decision Outcome
+
+Chosen option: Options 1, 2 and 3.
+These changes make it more likely that clients will be interoperable, because they make shared assumptions about how those URLs work, and since clients are already using HTTP to access the API, it makes sense to use it for media objects as well.
+Option 3 has a weaker justification, but in the absence of many implementations of TAMS (clients or servers) it makes sense to make it more flexible when the amount of change required to meet that flexibility is small.
+
+### Consequences
+
+* This is a breaking change to the API, and will trigger a major version increment
+* However most existing client and store implementations already implement Options 1 and 2, so only the change to `get_urls` requires new code.
+
+### Implementation
+
+Implemented in <https://github.com/bbc/tams/pull/36>
+
+## Pros and Cons of the Options
+
+### Option 1: Make `get_url` mandatory in Flow Segments
+
+Make the `get_url` property mandatory in the response to Flow Segment GET requests when using the "http_object_store" type (the only type currently described).
+Similarly, make the `put_url` mandatory in the response to a request to the storage endpoint.
+
+<!-- This is an optional element. Feel free to remove. -->
+{example | description | pointer to more information | …}
+
+* Good, because it ensures clients are able to read and write media essence without needing additional protocols
+* Good, because as a result it improves interoperability between client types
+* Bad, because the spec will have to change to allow other backends, however relaxing restrictions in the spec is relatively easy to achieve
+
+### Option 2: Stipulate that requests to `get_url` should include same-origin credentials
+
+Stipulate in the description for `get_url` that clients should send the credentials used to access the API itself if the provided URL is on the same origin as the API endpoint (as understood by the [Same Origin Policy](https://developer.mozilla.org/en-US/docs/Web/Security/Same-origin_policy)) and otherwise should send no credentials.
+As a result, for requests to different origins the API service should embed suitable credentials in the URL.
+The spec should also indicate that clients should use consider the URLs they receive to be ephemeral, and to make a new request to the API in the case of a 403 Forbidden response, to avoid giving out long-lived URLs which could present a security risk.
+This aligns with how pre-signed URLs in services like AWS S3 work.
+
+* Good, because it allows flexibility in implementation to either access an endpoint hosted by the API server, or separate the metadata and data planes using managed cloud services.
+* Good, because it aligns with the default behaviour in the [WhatWG Fetch Standard](https://fetch.spec.whatwg.org/#concept-request-credentials-mode) which sends credentials when the request is to the same origin.
+* Good, because it allows implementations to apply security measures to the URLs they provide.
+
+### Option 3: Make `get_url` a list of `get_urls`
+
+Replace the `get_url` in a Flow Segment response with an array of `get_urls`, where a client can choose any of the items in that array.
+Indicate that the list is sorted in order of the API server's preference - e.g. in the absence of any other reason clients should choose the first in the list.
+Include a label alongside each `get_url` to describe its purpose.
+
+* Good, because there are some use cases that would benefit from the `get_url` in a FlowSegment response being an array rather than a single value.
+  For example a workflow could be implemented that accepts input from "A" and "B" contribution legs in a hitless switching arrangement, and proceeds to record both.

--- a/docs/adr/decisions/0015-flow-segment-get-url-expectations.md
+++ b/docs/adr/decisions/0015-flow-segment-get-url-expectations.md
@@ -1,5 +1,5 @@
 ---
-status: "proposed"
+status: "accepted"
 ---
 # Make FlowSegment get_url expectations clearer
 

--- a/docs/adr/decisions/0015-flow-segment-get-url-expectations.md
+++ b/docs/adr/decisions/0015-flow-segment-get-url-expectations.md
@@ -38,9 +38,6 @@ Implemented in <https://github.com/bbc/tams/pull/36>
 Make the `get_url` property mandatory in the response to Flow Segment GET requests when using the "http_object_store" type (the only type currently described).
 Similarly, make the `put_url` mandatory in the response to a request to the storage endpoint.
 
-<!-- This is an optional element. Feel free to remove. -->
-{example | description | pointer to more information | …}
-
 * Good, because it ensures clients are able to read and write media essence without needing additional protocols
 * Good, because as a result it improves interoperability between client types
 * Bad, because the spec will have to change to allow other backends, however relaxing restrictions in the spec is relatively easy to achieve


### PR DESCRIPTION
# Details
Adds an ADR proposing some clarifications on how the `get_url` field on Flow Segments work:
- Makes `get_url` mandatory in Flow Segment responses
- Clarifies expectations around credentials when making segment requests
- Replaces `get_url` with a list of `get_urls`

# Pivotal Story (if relevant)
Story URL: https://www.pivotaltracker.com/story/show/187054769

# Related PRs
N/A

# Submitter PR Checks
_(tick as appropriate)_

- [X] PR completes task/fixes bug
- [X] API version has been incremented if necessary
- [ ] ADR status has been updated, and ADR implementation has been recorded
- [X] Documentation updated (README, etc.)
- [X] PR added to Pivotal story (if relevant)
- [ ] Follow-up stories added to Pivotal

# Reviewer PR Checks
_(tick as appropriate)_

- [ ] PR completes task/fixes bug
- [ ] Design makes sense, and fits with our current code base
- [ ] Code is easy to follow
- [ ] PR size is sensible
- [ ] Commit history is sensible and tidy

# Info on PRs
The checks above are guidelines. They don't all have to be ticked, but they should all have been considered.
