### PR TITLE
Add event stream

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,6 +133,14 @@ In the diagram below, portions of Flow X and Flow Y are combined to form Flow Z,
 
 ![Graphic showing the Flow timeline and Flow Segments of Flows X, Y and Z, where Z is composed of a mix of re-used segments and new media](./docs/images/Flow%20and%20Media%20Timelines-Flow%20XYZ.drawio.png)
 
+### Events from the API
+
+The TAMS API specifies a list of event messages that should be generated and sent to interested clients in response to certain events, such as the creation of a new Flow.
+This is intended to reduce the amount of polling required by clients to keep up with activity on a store by providing a way to push updates about content they have access to instead.
+
+However the specification is deliberately left open-ended; only the message bodies are specified, but not the protocol by which they are carried nor the method by which clients subscribe.
+It is assumed that implementations will provide a suitable mechanism, such as a call to allow clients to subscribe to webhooks, or details of an event bus to connect to and receive the messages.
+
 ### API Versioning
 
 The API is versioned using a major and minor version number.

--- a/api/TimeAddressableMediaStore.yaml
+++ b/api/TimeAddressableMediaStore.yaml
@@ -1293,11 +1293,32 @@ webhooks:
                 timerange:
                   $ref: 'schemas/timerange.json'
 
-  # TODO: Should Sources get created/deleted events too? If creation and deletion is a side effect of the same operation
-  # on Flows then it's strictly un-necessary, but if you're a client that only really deals in Sources, maybe you'd
-  # want that too?
+  sources/created:
+    post:
+      security:
+        - {}
+      requestBody:
+        content:
+          application/json:
+            schema:
+              title: Source Created Notification
+              description: Information about a Source which has been newly created in this store instance
+              required:
+                - event_timestamp
+                - event_type
+                - source
+              properties:
+                event_timestamp:
+                  description: Timestamp at which the new Source was created
+                  type: string
+                  format: date-time
+                event_type:
+                  type: string
+                  const: sources/created
+                source:
+                  $ref: "schemas/source.json"
 
-  source/updated:
+  sources/updated:
     post:
       security:
         - {}
@@ -1318,10 +1339,34 @@ webhooks:
                   format: date-time
                 event_type:
                   type: string
-                  const: source/updated
-                flow:
+                  const: sources/updated
+                source:
                   $ref: "schemas/source.json"
 
+  sources/deleted:
+    post:
+      security:
+        - {}
+      requestBody:
+        content:
+          application/json:
+            schema:
+              title: Source Deleted Notification
+              description: Notification that a Source has been deleted.
+              required:
+                - event_timestamp
+                - event_type
+                - source_id
+              properties:
+                event_timestamp:
+                  description: Timestamp at which the Source was modified
+                  type: string
+                  format: date-time
+                event_type:
+                  type: string
+                  const: sources/deleted
+                source_id:
+                  $ref: "#/components/schemas/uuid"
 
 components:
   schemas:

--- a/api/TimeAddressableMediaStore.yaml
+++ b/api/TimeAddressableMediaStore.yaml
@@ -1152,6 +1152,177 @@ paths:
                 $ref: schemas/deletion-request.json
               example:
                 $ref: examples/deletion-request-get-200.json
+
+webhooks:
+  flows/created:
+    post:
+      security:
+        - {}
+      requestBody:
+        content:
+          application/json:
+            schema:
+              title: Flow Created Notification
+              description: Information about a Flow which has been newly created in this store instance
+              required:
+                - event_timestamp
+                - event_type
+                - flow
+              properties:
+                event_timestamp:
+                  description: Timestamp at which the new Flow was created
+                  type: string
+                  format: date-time
+                event_type:
+                  type: string
+                  const: flows/created
+                flow:
+                  $ref: "schemas/flow-core.json"
+
+  flows/updated:
+    post:
+      security:
+        - {}
+      requestBody:
+        content:
+          application/json:
+            schema:
+              title: Flow Updated Notification
+              description: Information about a Flow for which the metadata has been modified.
+              required:
+                - event_timestamp
+                - event_type
+                - flow
+              properties:
+                event_timestamp:
+                  description: Timestamp at which the Flow was modified
+                  type: string
+                  format: date-time
+                event_type:
+                  type: string
+                  const: flows/updated
+                flow:
+                  $ref: "schemas/flow-core.json"
+
+  flows/deleted:
+    post:
+      security:
+        - {}
+      requestBody:
+        content:
+          application/json:
+            schema:
+              title: Flow Deleted Notification
+              description: Notification that a Flow has been deleted (or scheduled for deletion).
+              required:
+                - event_timestamp
+                - event_type
+                - flow_id
+              properties:
+                event_timestamp:
+                  description: Timestamp at which the Flow was modified
+                  type: string
+                  format: date-time
+                event_type:
+                  type: string
+                  const: flows/deleted
+                flow_id:
+                  $ref: "#/components/schemas/uuid"
+
+  flows/segments_added:
+    post:
+      security:
+        - {}
+      requestBody:
+        content:
+          application/json:
+            schema:
+              title: Flow Segments Added
+              description: |
+                Notification that new segments have been added to a Flow. The message body contains the timerange
+                covered by the new segments, however implementations MAY rate limit these messages and provide a single
+                message covering multiple segments. The timerange in the message MUST intersect with a segment at both
+                start and end (e.g. it cannot start or end in empty space).
+              required:
+                - event_timestamp
+                - event_type
+                - flow_id
+                - timerange
+              properties:
+                event_timestamp:
+                  description: Timestamp at which the most recent segment in the timerange was added (and the message generated)
+                  type: string
+                  format: date-time
+                event_type:
+                  type: string
+                  const: flows/segments_added
+                flow_id:
+                  $ref: "#/components/schemas/uuid"
+                timerange:
+                  $ref: 'schemas/timerange.json'
+
+  flows/segments_deleted:
+    post:
+      security:
+        - {}
+      requestBody:
+        content:
+          application/json:
+            schema:
+              title: Flow Segments Deleted
+              description: |
+                Notification that segments have been deleted from a Flow. The message body contains the timerange over
+                which segments have been deleted, however implementations MAY rate limit these messages and provide a
+                single message covering multiple segments. The timerange in the message MUST intersect with a segment
+                which has been deleted at both start and end (e.g. it cannot start or end in empty space).
+              required:
+                - event_timestamp
+                - event_type
+                - flow_id
+                - timerange
+              properties:
+                event_timestamp:
+                  description: Timestamp at which the most recent segment in the timerange was added (and the message generated)
+                  type: string
+                  format: date-time
+                event_type:
+                  type: string
+                  const: flows/segments_added
+                flow_id:
+                  $ref: "#/components/schemas/uuid"
+                timerange:
+                  $ref: 'schemas/timerange.json'
+
+  # TODO: Should Sources get created/deleted events too? If creation and deletion is a side effect of the same operation
+  # on Flows then it's strictly un-necessary, but if you're a client that only really deals in Sources, maybe you'd
+  # want that too?
+
+  source/updated:
+    post:
+      security:
+        - {}
+      requestBody:
+        content:
+          application/json:
+            schema:
+              title: Source Updated Notification
+              description: Information about a Source for which the metadata has been modified.
+              required:
+                - event_timestamp
+                - event_type
+                - source
+              properties:
+                event_timestamp:
+                  description: Timestamp at which the Source was modified
+                  type: string
+                  format: date-time
+                event_type:
+                  type: string
+                  const: source/updated
+                flow:
+                  $ref: "schemas/source.json"
+
+
 components:
   schemas:
     uuid:

--- a/api/TimeAddressableMediaStore.yaml
+++ b/api/TimeAddressableMediaStore.yaml
@@ -116,6 +116,85 @@ paths:
           description: Success. The service info has been updated.
         "400":
           description: Bad request. Invalid service JSON.
+  /service/webhooks:
+    head:
+      description: Return webhooks path headers
+      operationId: HEAD_webhooks
+      tags:
+        - Webhooks
+      responses:
+        "200":
+          $ref: '#/components/responses/trait_resource_listing_head_200'
+        "404":
+          description: "Webhooks are not supported by this API implementation"
+
+    get:
+      summary: List registered webhook URLs
+      description: |
+        Get the list of registered webhook URLs. Implementations SHOULD take steps to avoid displaying URLs to users
+        other than those who have suitable permissions (e.g. the owning user).
+        Availability of this endpoint is indicated by the name "webhooks" appearing in the `event_stream_mechanisms`
+        list on the service endpoint.
+
+      operationId: GET_webhooks
+      tags:
+        - Webhooks
+      responses:
+        "200":
+          description: Return the list of known webhook URLs. Note that the `secret` will be omitted.
+          content:
+            application/json:
+              example:
+                - url: https://hook.example.com
+                  events:
+                    - flows/created
+                    - flows/updated
+                    - flows/deleted
+              schema:
+                type: array
+                items:
+                  $ref: "schemas/webhook.json"
+        "404":
+          description: "Webhooks are not supported by this API implementation"
+
+    post:
+      summary: Register a webhook URL
+      description: |
+        Register to receive event notifications as webhooks on a specified URL. Webhook messages will conform to the
+        format in the `webhooks` section of the API docs, depending on the event type (as defined in the same section).
+        Availability of this endpoint is indicated by the name "webhooks" appearing in the `event_stream_mechanisms`
+        list on the service endpoint.
+
+        Making a POST request to this endpoint with the same URL and secret but a different list of `events` SHOULD
+        update the existing registration. POSTing an empty list of events SHOULD remove the registration.
+
+        HTTP requests from the service SHOULD include a `X-Hook-Signature` header containing the HMAC hex digest of the
+        webhook body, hashed using SHA-256 using the shared secret as the key. Clients SHOULD verify each message using
+        the shared secret.
+
+        API implementations SHOULD consider the security implementations of providing webhooks, and include appropriate
+        mitigations against Server Side Request Forgery (SSRF) attacks and similar.
+      operationId: POST_webhooks
+      tags:
+        - Webhooks
+      requestBody:
+        content:
+          application/json:
+            example:
+              url: https://hook.example.com
+              secret: super-secret-string
+              events:
+                - flows/created
+                - flows/updated
+            schema:
+              $ref: schemas/webhook.json
+        required: true
+      responses:
+        "200":
+          description: Success. The webhook has been registered
+        "404":
+          description: "Webhooks are not supported by this API implementation"
+
   /sources:
     head:
       summary: List Sources
@@ -1452,3 +1531,5 @@ tags:
     description: The system that stores the media objects referenced by flow segments.
   - name: FlowDeleteRequests
     description: Resource for monitoring long running deletion of flows and flow segments.
+  - name: Webhooks
+    description: Configures webhooks to deliver notifications externally. Optional, and may not be implemented

--- a/api/examples/service-get-200.json
+++ b/api/examples/service-get-200.json
@@ -5,5 +5,11 @@
   "version": "1.0+tams.1.10.0-da88b8b",
   "media_store": {
     "type": "http_object_store"
-  }
+  },
+  "event_stream_mechanisms": [
+    {
+      "name": "webhook",
+      "docs": "https://bbc.github.io/tams/#/operations/POST_webhooks"
+    }
+  ]
 }

--- a/api/schemas/event-stream-common.json
+++ b/api/schemas/event-stream-common.json
@@ -1,0 +1,22 @@
+{
+    "type": "object",
+    "description": "Describes an event stream mechanism available in this implementation of TAMS",
+    "title": "Event Stream Mechanism",
+    "required": [
+        "name"
+    ],
+    "properties": {
+        "name": {
+            "description": "Name of this type of event stream mechanism. Must be unique. Any name defined in this specification is reserved",
+            "type": "string"
+        },
+        "docs": {
+            "description": "Location (e.g. a URL) at which documentation for this event stream mechanism may be found",
+            "type": "string"
+        },
+        "config": {
+            "type": "object",
+            "description": "Configuration options required to make use of this mechanism"
+        }
+    }
+}

--- a/api/schemas/service.json
+++ b/api/schemas/service.json
@@ -37,6 +37,13 @@
           "enum": ["http_object_store"]
         }
       }
+    },
+    "event_stream_mechanisms": {
+      "type": "array",
+      "description": "List the types of event stream that this implementation supports",
+      "items": {
+        "$ref": "event-stream-common.json"
+      }
     }
   }
 }

--- a/api/schemas/webhook.json
+++ b/api/schemas/webhook.json
@@ -1,0 +1,26 @@
+{
+    "title": "Register Webhook",
+    "description": "Register to receive updates via webhook",
+    "type": "object",
+    "required": [
+        "url",
+        "events"
+    ],
+    "properties": {
+        "url": {
+            "description": "The URL to which the API should make HTTP POST requests with event data",
+            "type": "string"
+        },
+        "secret": {
+            "description": "A shared secret, used to sign deliveries to clients so they can validate the source",
+            "type": "string"
+        },
+        "events": {
+            "description": "List of event types to receive",
+            "type": "array",
+            "items": {
+                "type": "string"
+            }
+        }
+    }
+}

--- a/docs/adr/decisions/0014-add-event-stream.md
+++ b/docs/adr/decisions/0014-add-event-stream.md
@@ -1,0 +1,65 @@
+---
+status: "proposed"
+---
+# Add an event stream to the TAMS API
+
+## Context and Problem Statement
+
+Many process rely on waiting for something to happen and then taking an action, for example waiting for a Flow to be created or a particular timerange to become available, before reading it in to another process.
+As it stands, clients must continually poll the API to wait for an update, which is inefficient.
+A push based notification approach would both allow clients to respond to notification events more quickly, and consume fewer resources both on the API server and the clients.
+
+## Considered Options
+
+* Option 1: Specify a/a number of supported notification mechanisms that clients can subscribe to
+* Option 2: Specify only the content of notifications messages
+* Option 3: Provide a telemetry output which can also be used to trigger other actions
+
+## Decision Outcome
+
+Chosen option: "{title of option 1}", because
+{Justification, e.g., only option which resolves requirements, or comes out best (see below)}.
+
+<!-- This is an optional element. Feel free to remove. -->
+### Consequences
+
+* Good, because {positive consequence, e.g., improvement of one or more desired qualities, …}
+* Bad, because {negative consequence, e.g., compromising one or more desired qualities, …}
+* … <!-- numbers of consequences can vary -->
+
+<!-- This is an optional element. Feel free to remove. -->
+### Implementation
+
+{Once the proposal has been implemented, add a link to the relevant PRs here}
+
+<!-- This is an optional element. Feel free to remove. -->
+## Pros and Cons of the Options
+
+### Option 1: Specify a/a number of supported notification mechanisms that clients can subscribe to
+
+Document a mechanism that API servers must implement to provide push notifications, such as AWS SNS topics, use of Apache Kafka, MQTT or sending webhooks to specified subscribe URLs.
+Also document the messages that should be sent, and a mechanism to allow clients to subscribe to messages of interest.
+
+* Good, because it provides a fully specified method that can be integrated with all clients.
+* Good, because it allows the messages to be semantically relevant to the API, rather than the very "noisy" approach proposed in Option 3.
+* Neutral, because servers and clients will have to negotiate to choose a method they both support.
+* Bad, because the method(s) chosen will inevitably constrain out some options.
+
+### Option 2: Specify only the content of notification messages
+
+Document the messages that will be sent in response to certain events, without stipulating exactly how those messages are sent.
+
+* Good, because it allows implementations considerable flexibility in the approach they adopt.
+  For example one implementation could allow clients to provide a webhook URL, and another could use a managed event bus like AWS EventBridge.
+* Bad, because additional implementation-specific documentation is required.
+* Bad, because a client may not know in advance which mechanisms a server implements.
+  However it may be possible to use polling as a fallback, and responding to notifications is likely to be a separate implementation to a regular TAMS client anyway.
+
+### Option 3: Provide a telemetry output which can also be used to trigger other actions
+
+Stipulate that implementations supply a telemetry feed of logs, metrics and traces; for example using [OpenTelemetry](https://opentelemetry.io/docs/what-is-opentelemetry/).
+While primarily this is intended to be used for observability of the service, it could also be used to trigger events in other systems using the same data stream.
+
+* Good, because it uses a standard, well-defined format.
+* Bad, because the resulting data stream will be very noisy (containing traces of activity throughout the entire API server).
+* Bad, because the output logs and traces may leak detail intended to be internal to the API.

--- a/docs/adr/decisions/0014-add-event-stream.md
+++ b/docs/adr/decisions/0014-add-event-stream.md
@@ -12,27 +12,18 @@ A push based notification approach would both allow clients to respond to notifi
 ## Considered Options
 
 * Option 1: Specify a/a number of supported notification mechanisms that clients can subscribe to
-* Option 2: Specify only the content of notifications messages
+* Option 2: Specify only the content of notification messages
+* Option 2a: Specify the content of notification messages, plus some example implementations
 * Option 3: Provide a telemetry output which can also be used to trigger other actions
 
 ## Decision Outcome
 
-Chosen option: "{title of option 1}", because
-{Justification, e.g., only option which resolves requirements, or comes out best (see below)}.
+Chosen option: Option 2a: Specify the content of notification messages, plus some example implementations, because it allows flexibility in the notification mechanism, while providing a framework to document known mechanisms.
 
-<!-- This is an optional element. Feel free to remove. -->
-### Consequences
-
-* Good, because {positive consequence, e.g., improvement of one or more desired qualities, …}
-* Bad, because {negative consequence, e.g., compromising one or more desired qualities, …}
-* … <!-- numbers of consequences can vary -->
-
-<!-- This is an optional element. Feel free to remove. -->
 ### Implementation
 
-{Once the proposal has been implemented, add a link to the relevant PRs here}
+Implemented by <https://github.com/bbc/tams/pull/39>
 
-<!-- This is an optional element. Feel free to remove. -->
 ## Pros and Cons of the Options
 
 ### Option 1: Specify a/a number of supported notification mechanisms that clients can subscribe to
@@ -54,6 +45,16 @@ Document the messages that will be sent in response to certain events, without s
 * Bad, because additional implementation-specific documentation is required.
 * Bad, because a client may not know in advance which mechanisms a server implements.
   However it may be possible to use polling as a fallback, and responding to notifications is likely to be a separate implementation to a regular TAMS client anyway.
+
+### Option 2a: Specify the content of notification messages, plus some example implementations
+
+As with Option 2, but also specify at least one example mechanism.
+In addition, add a space to the `service` endpoint that signals which notification mechanisms this implementation supports, with an option to define new mechanisms not originally present.
+
+* Good, because it retains the flexibility of Option 2 if implementations aren't required to use one of the examples.
+* Good, because it helps build consensus, especially if other implementations use the example.
+* Good, because it provides a way to signal what an API implementation supports.
+* Neutral, because further example implementations need to be managed and added to the API documentation in due course.
 
 ### Option 3: Provide a telemetry output which can also be used to trigger other actions
 


### PR DESCRIPTION
# Details
Adds an ADR proposing a couple of possible approaches to an event notification stream, along with a proposal about what the message format might look like.

I think Option 3 (telemetry) probably doesn't make sense, but I'd appreciate thoughts on Option 1 (specify notification mechanism) vs Option 2 (leave it up to implementations). For now I've done the implementation for Option 2, but Option 1 is a build on that.

Also, it might seem like [AsyncAPI](https://www.asyncapi.com/) is the better fit for describing this, but it's quite high-friction for both HTTP webhooks and AWS EventBridge, which are the two possible implementations we've previously talked about, so using OpenAPI seemed the better approach for a spec.

I'd also appreciate thoughts on how Sources should work - see comments in the OpenAPI doc.

# Pivotal Story (if relevant)
Story URL: https://www.pivotaltracker.com/story/show/187071067

# Related PRs
N/A

# Submitter PR Checks
_(tick as appropriate)_

- [X] PR completes task/fixes bug
- [X] API version has been incremented if necessary
- [ ] ADR status has been updated, and ADR implementation has been recorded
- [X] Documentation updated (README, etc.)
- [X] PR added to Pivotal story (if relevant)
- [ ] Follow-up stories added to Pivotal

# Reviewer PR Checks
_(tick as appropriate)_

- [ ] PR completes task/fixes bug
- [ ] Design makes sense, and fits with our current code base
- [ ] Code is easy to follow
- [ ] PR size is sensible
- [ ] Commit history is sensible and tidy

# Info on PRs
The checks above are guidelines. They don't all have to be ticked, but they should all have been considered.
