### PR TITLE
Modify the webhooks api

### DIFF
--- a/api/TimeAddressableMediaStore.yaml
+++ b/api/TimeAddressableMediaStore.yaml
@@ -170,7 +170,7 @@ paths:
         of `events` SHOULD update the existing registration. POSTing an empty list of events SHOULD remove the
         registration.
 
-        HTTP requests from the service SHOULD include a `api_key_name` header with the 'api_key_value' value.
+        HTTP requests from the service SHOULD include a `api_key_name` header with the 'api_key_value' value. Clients SHOULD verify this against the value they provided when registering the webhook.
 
         API implementations SHOULD consider the security implementations of providing webhooks, and include appropriate
         mitigations against Server Side Request Forgery (SSRF) attacks and similar.

--- a/api/TimeAddressableMediaStore.yaml
+++ b/api/TimeAddressableMediaStore.yaml
@@ -191,8 +191,10 @@ paths:
               $ref: schemas/webhook-post.json
         required: true
       responses:
-        "200":
-          description: Success. The webhook has been registered
+        "201":
+          description: Success. The webhook has been registered or updated
+        "204":
+          description: Success. The webhook has been removed
         "404":
           description: "Webhooks are not supported by this API implementation"
 

--- a/api/TimeAddressableMediaStore.yaml
+++ b/api/TimeAddressableMediaStore.yaml
@@ -141,11 +141,12 @@ paths:
         - Webhooks
       responses:
         "200":
-          description: Return the list of known webhook URLs. Note that the `secret` will be omitted.
+          description: Return the list of known webhook URLs. Note that the `api_key_value` will be omitted.
           content:
             application/json:
               example:
                 - url: https://hook.example.com
+                  api_key_name: Authorization
                   events:
                     - flows/created
                     - flows/updated
@@ -165,12 +166,11 @@ paths:
         Availability of this endpoint is indicated by the name "webhooks" appearing in the `event_stream_mechanisms`
         list on the service endpoint.
 
-        Making a POST request to this endpoint with the same URL and secret but a different list of `events` SHOULD
-        update the existing registration. POSTing an empty list of events SHOULD remove the registration.
+        Making a POST request to this endpoint with the same URL, API key name and value but a different list
+        of `events` SHOULD update the existing registration. POSTing an empty list of events SHOULD remove the
+        registration.
 
-        HTTP requests from the service SHOULD include a `X-Hook-Signature` header containing the HMAC hex digest of the
-        webhook body, hashed using SHA-256 using the shared secret as the key. Clients SHOULD verify each message using
-        the shared secret.
+        HTTP requests from the service SHOULD include a `api_key_name` header with the 'api_key_value' value.
 
         API implementations SHOULD consider the security implementations of providing webhooks, and include appropriate
         mitigations against Server Side Request Forgery (SSRF) attacks and similar.
@@ -182,12 +182,13 @@ paths:
           application/json:
             example:
               url: https://hook.example.com
-              secret: super-secret-string
+              api_key_name: Authorization
+              api_key_value: Bearer 21238dksdjqwpqscj9
               events:
                 - flows/created
                 - flows/updated
             schema:
-              $ref: schemas/webhook.json
+              $ref: schemas/webhook-post.json
         required: true
       responses:
         "200":

--- a/api/TimeAddressableMediaStore.yaml
+++ b/api/TimeAddressableMediaStore.yaml
@@ -1322,7 +1322,7 @@ webhooks:
                     - flow
                   properties:
                     flow:
-                      $ref: "schemas/flow-core.json"
+                      $ref: "schemas/flow.json"
 
   flows/updated:
     post:
@@ -1352,7 +1352,7 @@ webhooks:
                     - flow
                   properties:
                     flow:
-                      $ref: "schemas/flow-core.json"
+                      $ref: "schemas/flow.json"
 
   flows/deleted:
     post:

--- a/api/TimeAddressableMediaStore.yaml
+++ b/api/TimeAddressableMediaStore.yaml
@@ -1305,7 +1305,7 @@ webhooks:
               required:
                 - event_timestamp
                 - event_type
-                - flow
+                - event
               properties:
                 event_timestamp:
                   description: Timestamp at which the new Flow was created
@@ -1314,8 +1314,13 @@ webhooks:
                 event_type:
                   type: string
                   const: flows/created
-                flow:
-                  $ref: "schemas/flow-core.json"
+                event:
+                  type: object
+                  required:
+                    - flow
+                  properties:
+                    flow:
+                      $ref: "schemas/flow-core.json"
 
   flows/updated:
     post:
@@ -1330,7 +1335,7 @@ webhooks:
               required:
                 - event_timestamp
                 - event_type
-                - flow
+                - event
               properties:
                 event_timestamp:
                   description: Timestamp at which the Flow was modified
@@ -1339,8 +1344,13 @@ webhooks:
                 event_type:
                   type: string
                   const: flows/updated
-                flow:
-                  $ref: "schemas/flow-core.json"
+                event:
+                  type: object
+                  required:
+                    - flow
+                  properties:
+                    flow:
+                      $ref: "schemas/flow-core.json"
 
   flows/deleted:
     post:
@@ -1355,7 +1365,7 @@ webhooks:
               required:
                 - event_timestamp
                 - event_type
-                - flow_id
+                - event
               properties:
                 event_timestamp:
                   description: Timestamp at which the Flow was modified
@@ -1364,8 +1374,13 @@ webhooks:
                 event_type:
                   type: string
                   const: flows/deleted
-                flow_id:
-                  $ref: "#/components/schemas/uuid"
+                event:
+                  type: object
+                  required:
+                    - flow_id
+                  properties:
+                    flow_id:
+                      $ref: "#/components/schemas/uuid"
 
   flows/segments_added:
     post:
@@ -1384,8 +1399,7 @@ webhooks:
               required:
                 - event_timestamp
                 - event_type
-                - flow_id
-                - timerange
+                - event
               properties:
                 event_timestamp:
                   description: Timestamp at which the most recent segment in the timerange was added (and the message generated)
@@ -1394,10 +1408,16 @@ webhooks:
                 event_type:
                   type: string
                   const: flows/segments_added
-                flow_id:
-                  $ref: "#/components/schemas/uuid"
-                timerange:
-                  $ref: 'schemas/timerange.json'
+                event:
+                  type: object
+                  required:
+                    - flow_id
+                    - timerange
+                  properties:
+                    flow_id:
+                      $ref: "#/components/schemas/uuid"
+                    timerange:
+                      $ref: 'schemas/timerange.json'
 
   flows/segments_deleted:
     post:
@@ -1416,8 +1436,7 @@ webhooks:
               required:
                 - event_timestamp
                 - event_type
-                - flow_id
-                - timerange
+                - event
               properties:
                 event_timestamp:
                   description: Timestamp at which the most recent segment in the timerange was added (and the message generated)
@@ -1426,10 +1445,16 @@ webhooks:
                 event_type:
                   type: string
                   const: flows/segments_added
-                flow_id:
-                  $ref: "#/components/schemas/uuid"
-                timerange:
-                  $ref: 'schemas/timerange.json'
+                event:
+                  type: object
+                  required:
+                    - flow_id
+                    - timerange
+                  properties:
+                    flow_id:
+                      $ref: "#/components/schemas/uuid"
+                    timerange:
+                      $ref: 'schemas/timerange.json'
 
   sources/created:
     post:
@@ -1444,7 +1469,7 @@ webhooks:
               required:
                 - event_timestamp
                 - event_type
-                - source
+                - event
               properties:
                 event_timestamp:
                   description: Timestamp at which the new Source was created
@@ -1453,8 +1478,13 @@ webhooks:
                 event_type:
                   type: string
                   const: sources/created
-                source:
-                  $ref: "schemas/source.json"
+                event:
+                  type: object
+                  required:
+                    - source
+                  properties:
+                    source:
+                      $ref: "schemas/source.json"
 
   sources/updated:
     post:
@@ -1469,7 +1499,7 @@ webhooks:
               required:
                 - event_timestamp
                 - event_type
-                - source
+                - event
               properties:
                 event_timestamp:
                   description: Timestamp at which the Source was modified
@@ -1478,8 +1508,13 @@ webhooks:
                 event_type:
                   type: string
                   const: sources/updated
-                source:
-                  $ref: "schemas/source.json"
+                event:
+                  type: object
+                  required:
+                    - source
+                  properties:
+                    source:
+                      $ref: "schemas/source.json"
 
   sources/deleted:
     post:
@@ -1494,7 +1529,7 @@ webhooks:
               required:
                 - event_timestamp
                 - event_type
-                - source_id
+                - event
               properties:
                 event_timestamp:
                   description: Timestamp at which the Source was modified
@@ -1503,8 +1538,13 @@ webhooks:
                 event_type:
                   type: string
                   const: sources/deleted
-                source_id:
-                  $ref: "#/components/schemas/uuid"
+                event:
+                  type: object
+                  required:
+                    - source_id
+                  properties:
+                    source_id:
+                      $ref: "#/components/schemas/uuid"
 
 components:
   schemas:

--- a/api/examples/service-get-200.json
+++ b/api/examples/service-get-200.json
@@ -8,7 +8,7 @@
   },
   "event_stream_mechanisms": [
     {
-      "name": "webhook",
+      "name": "webhooks",
       "docs": "https://bbc.github.io/tams/#/operations/POST_webhooks"
     }
   ]

--- a/api/schemas/webhook-post.json
+++ b/api/schemas/webhook-post.json
@@ -12,7 +12,7 @@
             "type": "string"
         },
         "api_key_name": {
-            "description": "The HTTP header name that is added to the event POST",
+            "description": "The HTTP header name that is added to the event POST with value 'api_key_value'",
             "type": "string"
         },
         "api_key_value": {


### PR DESCRIPTION
# Details
This PR modifies the webhook API following learnings from implementing it.

The `secret` is replaced by `api_key_name` and `api_key_value`. The `api_key_name` is the name (and `api_key_value` the value) of the HTTP header that is included when POSTing to the webhook URL.

The TAMS event was changed to have the `event` at the to level and the event data in there.

# Pivotal Story (if relevant)
Story URL: https://www.pivotaltracker.com/story/show/187360744

# Related PRs
_Where appropriate. Indicate order to be merged._

# Submitter PR Checks
_(tick as appropriate)_

- [ ] PR completes task/fixes bug
- [ ] API version has been incremented if necessary
- [ ] ADR status has been updated, and ADR implementation has been recorded
- [ ] Documentation updated (README, etc.)
- [ ] PR added to Pivotal story (if relevant)
- [ ] Follow-up stories added to Pivotal

# Reviewer PR Checks
_(tick as appropriate)_

- [ ] PR completes task/fixes bug
- [ ] Design makes sense, and fits with our current code base
- [ ] Code is easy to follow
- [ ] PR size is sensible
- [ ] Commit history is sensible and tidy

# Info on PRs
The checks above are guidelines. They don't all have to be ticked, but they should all have been considered.
