### PR TITLE
api: mention flow container not set in 400 error descriptions

### DIFF
--- a/api/TimeAddressableMediaStore.yaml
+++ b/api/TimeAddressableMediaStore.yaml
@@ -1146,7 +1146,7 @@ paths:
         "201":
           description: created. The flow segment has been created.
         "400":
-          description: Bad request. Invalid flow segment JSON.
+          description: Bad request. Invalid flow segment JSON or the flow 'container' is not set.
         "404":
           description: The flow does not exist.
     delete:
@@ -1234,7 +1234,7 @@ paths:
               example:
                 $ref: examples/flow-storage-post-201.json
         "400":
-          description: Bad request. Invalid flow storage request JSON.
+          description: Bad request. Invalid flow storage request JSON or the flow 'container' is not set.
         "404":
           description: The requested flow does not exist
   /flow-delete-requests:


### PR DESCRIPTION
# Details
POSTs to the /storage and /segments endpoints for flows with the "container" not set results in a 400 error because a flow without container does not have flow segments.

# Pivotal Story (if relevant)
Story URL: https://www.pivotaltracker.com/story/show/187593229

# Related PRs
_Where appropriate. Indicate order to be merged._

# Submitter PR Checks
_(tick as appropriate)_

- [ ] PR completes task/fixes bug
- [ ] API version has been incremented if necessary
- [ ] ADR status has been updated, and ADR implementation has been recorded
- [ ] Documentation updated (README, etc.)
- [ ] PR added to Pivotal story (if relevant)
- [ ] Follow-up stories added to Pivotal

# Reviewer PR Checks
_(tick as appropriate)_

- [ ] PR completes task/fixes bug
- [ ] Design makes sense, and fits with our current code base
- [ ] Code is easy to follow
- [ ] PR size is sensible
- [ ] Commit history is sensible and tidy

# Info on PRs
The checks above are guidelines. They don't all have to be ticked, but they should all have been considered.
