### PR TITLE
Audit of HTTP responses and schemas

### DIFF
--- a/api/TimeAddressableMediaStore.yaml
+++ b/api/TimeAddressableMediaStore.yaml
@@ -368,7 +368,7 @@ paths:
         "200":
           $ref: '#/components/responses/trait_resource_info_head_200'
         "404":
-          $ref: '#/components/responses/trait_resource_info_head_404'
+          description: The requested Source or tag does not exist.
     get:
       summary: Source Tag Value
       description: Return the tag value associated with the tag name.

--- a/api/TimeAddressableMediaStore.yaml
+++ b/api/TimeAddressableMediaStore.yaml
@@ -327,6 +327,8 @@ paths:
       responses:
         "200":
           $ref: '#/components/responses/trait_resource_listing_head_200'
+        "404":
+          description: The requested Source does not exist.
     get:
       summary: Source Tags
       description: Returns the Source tags.
@@ -405,6 +407,8 @@ paths:
           description: No content. The tag has been updated.
         "400":
           description: Bad request. Invalid Source tag value.
+        "404":
+          description: The requested Source does not exist, or the tag name in the path is invalid.
     delete:
       summary: Delete Source tag
       description: Delete a specific tag on a Source
@@ -414,6 +418,8 @@ paths:
       responses:
         "204":
           description: No content. The Source segment has been deleted.
+        "404":
+          description: The requested Source ID or tag in the path is invalid.
   /sources/{sourceId}/description:
     parameters:
       - name: sourceId
@@ -469,6 +475,8 @@ paths:
           description: No content. The description has been updated.
         "400":
           description: Bad request. Invalid Source description.
+        "404":
+          description: The requested Source does not exist.
     delete:
       summary: Delete Source Description
       description: Delete the description property.
@@ -478,6 +486,8 @@ paths:
       responses:
         "204":
           description: No content. The Source description property has been deleted.
+        "404":
+          description: The Source ID in the path is invalid.
   /sources/{sourceId}/label:
     parameters:
       - name: sourceId
@@ -533,6 +543,8 @@ paths:
           description: No content. The label has been updated.
         "400":
           description: Bad request. Invalid Source label.
+        "404":
+          description: The requested Source does not exist.
     delete:
       summary: Delete Source Label
       description: Delete the label property.
@@ -542,6 +554,8 @@ paths:
       responses:
         "204":
           description: No content. The Source label property has been deleted.
+        "404":
+          description: The requested Source ID in the path is invalid.
   /flows:
     head:
       description: Return flows path headers
@@ -757,6 +771,8 @@ paths:
           description: Bad request. Invalid flow JSON.
         "403":
           description: Forbidden. You do not have permission to modify this flow. It may be marked read-only.
+        "404":
+          description: The requested Flow ID in the path is invalid.
     delete:
       description: |
         Deletes the flow and associated segments. If flow segment deletion
@@ -783,6 +799,8 @@ paths:
           description: No content. The flow has been deleted and the flow segments have been or will be deleted.
         "403":
           description: Forbidden. You do not have permission to modify this flow. It may be marked read-only.
+        "404":
+          description: The requested Flow ID in the path is invalid.
   /flows/{flowId}/tags:
     parameters:
       - name: flowId
@@ -799,6 +817,8 @@ paths:
       responses:
         "200":
           $ref: '#/components/responses/trait_resource_listing_head_200'
+        "404":
+          description: The requested flow does not exist.
     get:
       description: Returns the flow tags.
       operationId: GET_flows-flowId-tags
@@ -871,6 +891,8 @@ paths:
           description: Bad request. Invalid flow tag value.
         "403":
           description: Forbidden. You do not have permission to modify this flow. It may be marked read-only.
+        "404":
+          description: The requested flow does not exist.
     delete:
       description: Delete the tag.
       operationId: DELETE_flows-flowId-tags-name
@@ -881,6 +903,8 @@ paths:
           description: No content. The flow segment has been deleted.
         "403":
           description: Forbidden. You do not have permission to modify this flow. It may be marked read-only.
+        "404":
+          description: The requested flow ID in the path is invalid.
   /flows/{flowId}/description:
     parameters:
       - name: flowId
@@ -933,6 +957,8 @@ paths:
           description: Bad request. Invalid flow description.
         "403":
           description: Forbidden. You do not have permission to modify this flow. It may be marked read-only.
+        "404":
+          description: The requested flow does not exist.
     delete:
       description: Delete the description property.
       operationId: DELETE_flows-flowId-description
@@ -943,6 +969,8 @@ paths:
           description: No content. The flow description property has been deleted.
         "403":
           description: Forbidden. You do not have permission to modify this flow. It may be marked read-only.
+        "404":
+          description: The requested flow ID in the path is invalid.
   /flows/{flowId}/read_only:
     parameters:
       - name: flowId
@@ -993,6 +1021,8 @@ paths:
           description: No content. The read_only property has been updated.
         "400":
           description: Bad request. Invalid flow description.
+        "404":
+          description: The requested flow does not exist.
   /flows/{flowId}/segments:
     parameters:
       - name: flowId
@@ -1009,6 +1039,8 @@ paths:
       responses:
         "200":
           $ref: '#/components/responses/trait_resource_listing_head_200'
+        "404":
+          description: The requested flow does not exist.
     get:
       description: |
         Returns the flow segments.
@@ -1109,6 +1141,8 @@ paths:
                     $ref: examples/flow-segments-get-200-multiple-urls.json
         "400":
           description: Bad request. Invalid query options.
+        "404":
+          description: The requested flow does not exist.
     post:
       description: |
         Register a new flow segment, attaching the object id given to a point in the flow timeline.
@@ -1194,6 +1228,8 @@ paths:
           description: Bad request. Invalid query options.
         "403":
           description: Forbidden. You do not have permission to modify this flow. It may be marked read-only.
+        "404":
+          description: The requested flow ID in the path is invalid.
   /flows/{flowId}/storage:
     parameters:
       - name: flowId
@@ -1312,6 +1348,8 @@ paths:
                 $ref: schemas/deletion-request.json
               example:
                 $ref: examples/deletion-request-get-200.json
+        "404":
+          description: The requested flow delete request does not exist.
 webhooks:
   flows/created:
     post:

--- a/api/TimeAddressableMediaStore.yaml
+++ b/api/TimeAddressableMediaStore.yaml
@@ -365,8 +365,6 @@ paths:
       responses:
         "200":
           $ref: '#/components/responses/trait_resource_info_head_200'
-        "400":
-          $ref: '#/components/responses/trait_resource_info_head_400'
         "404":
           $ref: '#/components/responses/trait_resource_info_head_404'
     get:
@@ -431,8 +429,6 @@ paths:
       responses:
         "200":
           $ref: '#/components/responses/trait_resource_info_head_200'
-        "400":
-          $ref: '#/components/responses/trait_resource_info_head_400'
         "404":
           $ref: '#/components/responses/trait_resource_info_head_404'
     get:
@@ -497,8 +493,6 @@ paths:
       responses:
         "200":
           $ref: '#/components/responses/trait_resource_info_head_200'
-        "400":
-          $ref: '#/components/responses/trait_resource_info_head_400'
         "404":
           $ref: '#/components/responses/trait_resource_info_head_404'
     get:
@@ -657,8 +651,6 @@ paths:
       responses:
         "200":
           $ref: '#/components/responses/trait_resource_info_head_200'
-        "400":
-          $ref: '#/components/responses/trait_resource_info_head_400'
         "404":
           $ref: '#/components/responses/trait_resource_info_head_404'
     get:
@@ -839,8 +831,6 @@ paths:
       responses:
         "200":
           $ref: '#/components/responses/trait_resource_info_head_200'
-        "400":
-          $ref: '#/components/responses/trait_resource_info_head_400'
         "404":
           $ref: '#/components/responses/trait_resource_info_head_404'
     get:
@@ -903,8 +893,6 @@ paths:
       responses:
         "200":
           $ref: '#/components/responses/trait_resource_info_head_200'
-        "400":
-          $ref: '#/components/responses/trait_resource_info_head_400'
         "404":
           $ref: '#/components/responses/trait_resource_info_head_404'
     get:
@@ -967,8 +955,6 @@ paths:
       responses:
         "200":
           $ref: '#/components/responses/trait_resource_info_head_200'
-        "400":
-          $ref: '#/components/responses/trait_resource_info_head_400'
         "404":
           $ref: '#/components/responses/trait_resource_info_head_404'
     get:
@@ -1298,8 +1284,6 @@ paths:
       responses:
         "200":
           $ref: '#/components/responses/trait_resource_info_head_200'
-        "400":
-          $ref: '#/components/responses/trait_resource_info_head_400'
         "404":
           $ref: '#/components/responses/trait_resource_info_head_404'
     get:

--- a/api/TimeAddressableMediaStore.yaml
+++ b/api/TimeAddressableMediaStore.yaml
@@ -836,7 +836,7 @@ paths:
         "200":
           $ref: '#/components/responses/trait_resource_info_head_200'
         "404":
-          $ref: '#/components/responses/trait_resource_info_head_404'
+          description: The requested flow or tag does not exist.
     get:
       description: Return the tag value associated with the tag name.
       operationId: GET_flows-flowId-tags-name

--- a/api/TimeAddressableMediaStore.yaml
+++ b/api/TimeAddressableMediaStore.yaml
@@ -404,7 +404,7 @@ paths:
         "204":
           description: No content. The tag has been updated.
         "400":
-          description: Bad request. Invalid Source tag JSON array.
+          description: Bad request. Invalid Source tag value.
     delete:
       summary: Delete Source tag
       description: Delete a specific tag on a Source
@@ -868,7 +868,7 @@ paths:
         "204":
           description: No content. The tag has been updated.
         "400":
-          description: Bad request. Invalid flow tag JSON array.
+          description: Bad request. Invalid flow tag value.
         "403":
           description: Forbidden. You do not have permission to modify this flow. It may be marked read-only.
     delete:

--- a/api/TimeAddressableMediaStore.yaml
+++ b/api/TimeAddressableMediaStore.yaml
@@ -192,6 +192,8 @@ paths:
           description: Success. The webhook has been registered or updated
         "204":
           description: Success. The webhook has been removed
+        "400":
+          description: Bad request. Invalid parameters.
         "404":
           description: "Webhooks are not supported by this API implementation"
   /sources:
@@ -635,6 +637,8 @@ paths:
                 type: array
                 items:
                   $ref: "schemas/flow.json"
+        "400":
+          description: Bad request. Invalid query options.
   /flows/{flowId}:
     parameters:
       - name: flowId
@@ -1103,6 +1107,8 @@ paths:
                     expressed a preference for the "pipeline-a" URLs by putting them first in the list.
                   value:
                     $ref: examples/flow-segments-get-200-multiple-urls.json
+        "400":
+          description: Bad request. Invalid query options.
     post:
       description: |
         Register a new flow segment, attaching the object id given to a point in the flow timeline.
@@ -1184,6 +1190,8 @@ paths:
                 $ref: examples/deletion-request-get-200.json
         "204":
           description: No content. The flow segments have been or will be deleted.
+        "400":
+          description: Bad request. Invalid query options.
         "403":
           description: Forbidden. You do not have permission to modify this flow. It may be marked read-only.
   /flows/{flowId}/storage:

--- a/api/TimeAddressableMediaStore.yaml
+++ b/api/TimeAddressableMediaStore.yaml
@@ -1044,7 +1044,7 @@ paths:
         "200":
           $ref: '#/components/responses/trait_resource_listing_head_200'
         "404":
-          description: The requested flow does not exist.
+          description: The flow ID in the path is invalid.
     get:
       description: |
         Returns the flow segments.
@@ -1146,7 +1146,7 @@ paths:
         "400":
           description: Bad request. Invalid query options.
         "404":
-          description: The requested flow does not exist.
+          description: The flow ID in the path is invalid.
     post:
       description: |
         Register a new flow segment, attaching the object id given to a point in the flow timeline.

--- a/api/TimeAddressableMediaStore.yaml
+++ b/api/TimeAddressableMediaStore.yaml
@@ -496,7 +496,7 @@ paths:
         "200":
           $ref: '#/components/responses/trait_resource_info_head_200'
         "404":
-          $ref: '#/components/responses/trait_resource_info_head_404'
+          description: The requested Source does not exist, or does not have a label set.
     get:
       summary: Source Label
       description: Returns the Source label property.
@@ -513,7 +513,7 @@ paths:
               schema:
                 type: string
         "404":
-          description: The requested Source does not exist.
+          description: The requested Source does not exist, or does not have a label set.
     put:
       summary: Update Source Label
       description: Create or modify the label property.

--- a/api/TimeAddressableMediaStore.yaml
+++ b/api/TimeAddressableMediaStore.yaml
@@ -203,9 +203,37 @@ paths:
       operationId: HEAD_sources
       tags:
         - Sources
+      parameters:
+        - name: label
+          in: query
+          description: Filter on Sources that have the given label.
+          schema:
+            type: string
+        - name: tag.{name}
+          in: query
+          description: |
+            Filter on Sources that have a tag named {name} and with the given value.
+            The {name} could contain escaped characters to allow it to be used in a
+            URL.
+          schema:
+            type: string
+        - name: tag_exists.{name}
+          in: query
+          description: |
+            Filter on Sources that have a tag named {name} regardless of value. The
+            {name} could contain escaped characters to allow it to be used in a
+            URL. If set to true then the presence of the tag is filtered for. If set
+            to false then its absence is. If left out then no filtering on tag presence
+            is performed.
+          schema:
+            type: boolean
+        - $ref: '#/components/parameters/trait_resource_paged_key'
+        - $ref: '#/components/parameters/trait_paged_limit'
       responses:
         "200":
           $ref: '#/components/responses/trait_resource_listing_head_200'
+        "400":
+          $ref: '#/components/responses/trait_resource_info_head_400'
     get:
       summary: List Sources
       description: List the Sources registered in the store and their details.
@@ -262,6 +290,8 @@ paths:
                 type: array
                 items:
                   $ref: "schemas/source.json"
+        "400":
+          description: Bad request. Invalid query options.
   /sources/{sourceId}:
     parameters:
       - name: sourceId
@@ -279,8 +309,6 @@ paths:
       responses:
         "200":
           $ref: '#/components/responses/trait_resource_info_head_200'
-        "400":
-          $ref: '#/components/responses/trait_resource_info_head_400'
         "404":
           $ref: '#/components/responses/trait_resource_info_head_404'
     get:
@@ -562,9 +590,68 @@ paths:
       operationId: HEAD_flows
       tags:
         - Flows
+      parameters:
+        - name: source_id
+          in: query
+          description: Filter on source identifier.
+          schema:
+            $ref: '#/components/schemas/uuid'
+        - name: timerange
+          in: query
+          description: Filter on flows that overlap the given timerange.
+          schema:
+            default: _
+            $ref: 'schemas/timerange.json'
+        - name: format
+          in: query
+          description: Filter on flow format.
+          schema:
+            $ref: '#/components/schemas/flowformat'
+        - name: codec
+          in: query
+          description: Filter on flow codec.
+          schema:
+            $ref: '#/components/schemas/mimetype'
+        - name: label
+          in: query
+          description: Filter on flows that have the given label.
+          schema:
+            type: string
+        - name: tag.{name}
+          in: query
+          description: |
+            Filter on flows that have a tag named {name} and with the given value.
+            The {name} could contain escaped characters to allow it to be used in a
+            URL.
+          schema:
+            type: string
+        - name: tag_exists.{name}
+          in: query
+          description: |
+            Filter on flows that have a tag named {name} regardless of value. The
+            {name} could contain escaped characters to allow it to be used in a
+            URL. If set to true then the presence of the tag is filtered for. If set
+            to false then its absence is. If left out then no filtering on tag presence
+            is performed.
+          schema:
+            type: boolean
+        - name: frame_width
+          in: query
+          description: Filter on video flows that have the given frame width.
+          schema:
+            type: integer
+        - name: frame_height
+          in: query
+          description: Filter on video flows that have the given frame height.
+          schema:
+            type: integer
+        - $ref: '#/components/parameters/trait_resource_paged_key'
+        - $ref: '#/components/parameters/trait_paged_limit'
       responses:
         "200":
           $ref: '#/components/responses/trait_resource_listing_head_200'
+        "400":
+          description: Bad request. Invalid query options.
     get:
       description: List the flows registered in the store.
       operationId: GET_flows
@@ -666,9 +753,24 @@ paths:
       operationId: HEAD_flows-flowId
       tags:
         - Flows
+      parameters:
+        - name: include_timerange
+          in: query
+          description: Include the available segment timerange in the response.
+          schema:
+            default: false
+            type: boolean
+        - name: timerange
+          in: query
+          description: Limit the returned available segment timerange to this timerange.
+          schema:
+            default: _
+            $ref: 'schemas/timerange.json'
       responses:
         "200":
           $ref: '#/components/responses/trait_resource_info_head_200'
+        "400":
+          description: Bad request. Invalid query options.
         "404":
           $ref: '#/components/responses/trait_resource_info_head_404'
     get:
@@ -1040,9 +1142,25 @@ paths:
       operationId: HEAD_flows-flowId-segments
       tags:
         - FlowSegments
+      parameters:
+        - name: object_id
+          in: query
+          description: Filter on object identifier.
+          schema:
+            type: string
+        - name: reverse_order
+          in: query
+          description: Return segments in reverse time order.
+          schema:
+            default: false
+            type: boolean
+        - $ref: '#/components/parameters/trait_timerange_paged_timerange'
+        - $ref: '#/components/parameters/trait_paged_limit'
       responses:
         "200":
           $ref: '#/components/responses/trait_resource_listing_head_200'
+        "400":
+          description: Bad request. Invalid query options.
         "404":
           description: The flow ID in the path is invalid.
     get:

--- a/api/TimeAddressableMediaStore.yaml
+++ b/api/TimeAddressableMediaStore.yaml
@@ -831,6 +831,8 @@ paths:
             application/json:
               example:
                 $ref: examples/flow-tags-get-200.json
+              schema:
+                $ref: schemas/tags.json
         "404":
           description: The requested flow does not exist.
   /flows/{flowId}/tags/{name}:
@@ -869,6 +871,8 @@ paths:
             application/json:
               example:
                 $ref: examples/flow-tag-get-200.json
+              schema:
+                type: string
         "404":
           description: The requested flow or tag does not exist.
     put:

--- a/api/schemas/flow-audio.json
+++ b/api/schemas/flow-audio.json
@@ -42,7 +42,7 @@
               "exclusiveMinimum": 0
             },
             "bit_depth": {
-              "description": "The number of significant bits used to represent the audio sample. The minumum number of bytes then equals `round_up(bit_depth / 8)`.",
+              "description": "The number of significant bits used to represent the audio sample. The minumum number of bytes then equals `round_up(bit_depth / 8)`. If codec is `audio/x-raw-int` or `audio/x-raw-float`, bit_depth must be set.",
               "type": "integer",
               "exclusiveMinimum": 0
             },
@@ -69,7 +69,7 @@
               ],
               "properties": {
                 "unc_type": {
-                  "description": "The uncompressed audio multi-channel representation type.",
+                  "description": "The uncompressed audio multi-channel representation type. If codec is `audio/x-raw-int` or `audio/x-raw-float`, unc_type must be set.",
                   "type": "string",
                   "enum": [
                     "interleaved",

--- a/api/schemas/flow-audio.json
+++ b/api/schemas/flow-audio.json
@@ -42,7 +42,7 @@
               "exclusiveMinimum": 0
             },
             "bit_depth": {
-              "description": "The number of significant bits used to represent the audio sample. The minumum number of bytes then equals `round_up(bit_depth / 8)`. If codec is `audio/x-raw-int` or `audio/x-raw-float`, bit_depth must be set.",
+              "description": "The number of significant bits used to represent the audio sample. The minumum number of bytes then equals `round_up(bit_depth / 8)`. If codec is `audio/x-raw-int` bit_depth must be set. If codec is `audio/x-raw-float` bit_depth must be set to 32 or 64",
               "type": "integer",
               "exclusiveMinimum": 0
             },

--- a/api/schemas/flow-audio.json
+++ b/api/schemas/flow-audio.json
@@ -33,15 +33,18 @@
           "properties": {
             "sample_rate": {
               "description": "The fixed number of samples per second.",
-              "type": "integer"
+              "type": "integer",
+              "exclusiveMinimum": 0
             },
             "channels": {
               "description": "The channel count.",
-              "type": "integer"
+              "type": "integer",
+              "exclusiveMinimum": 0
             },
             "bit_depth": {
               "description": "The number of significant bits used to represent the audio sample. The minumum number of bytes then equals `round_up(bit_depth / 8)`.",
-              "type": "integer"
+              "type": "integer",
+              "exclusiveMinimum": 0
             },
             "codec_parameters": {
               "title": "Audio Codec Parameters",

--- a/api/schemas/flow-core.json
+++ b/api/schemas/flow-core.json
@@ -77,12 +77,12 @@
     "avg_bit_rate": {
       "description": "The average bit rate of the flow content in 1000 bits/second. A precise definition of how the bit rate is calculated is not provided here.",
       "type": "integer",
-      "exclusiveMinimum": 0
+      "minimum": 0
     },
     "max_bit_rate": {
       "description": "The maximum bit rate of the flow content in 1000 bits/second. A precise definition of how the bit rate is calculated is not provided here.",
       "type": "integer",
-      "exclusiveMinimum": 0
+      "minimum": 0
     },
     "timerange": {
       "description": "The timerange of samples available in the flow, as described by the [TimeRange](../schemas/timerange#top) type",

--- a/api/schemas/flow-core.json
+++ b/api/schemas/flow-core.json
@@ -42,7 +42,8 @@
     },
     "generation": {
       "description": "An indication of how many lossy encodings the flow content has been through. A flow with a higher generation may contain less of the original information than a flow with a lower generation.",
-      "type": "integer"
+      "type": "integer",
+      "minimum": 0
     },
     "created": {
       "description": "The date-time the flow was created in a given context, e.g. in the store. Implementations SHOULD ignore this if given in a PUT request, and instead manage it internally",
@@ -75,11 +76,13 @@
     },
     "avg_bit_rate": {
       "description": "The average bit rate of the flow content in 1000 bits/second. A precise definition of how the bit rate is calculated is not provided here.",
-      "type": "integer"
+      "type": "integer",
+      "exclusiveMinimum": 0
     },
     "max_bit_rate": {
       "description": "The maximum bit rate of the flow content in 1000 bits/second. A precise definition of how the bit rate is calculated is not provided here.",
-      "type": "integer"
+      "type": "integer",
+      "exclusiveMinimum": 0
     },
     "timerange": {
       "description": "The timerange of samples available in the flow, as described by the [TimeRange](../schemas/timerange#top) type",

--- a/api/schemas/flow-core.json
+++ b/api/schemas/flow-core.json
@@ -37,7 +37,7 @@
       "$ref": "tags.json"
     },
     "metadata_version": {
-      "description": "A change to the flow metadata, not including metadata_version, last_update or segments, results in a new version. If the metadata_version for flow instances is identical then the metadata is identical. (Unclear whether there is a strict ordering requirement, ie. if version a > version b then version b is newer or more correct than version a.)",
+      "description": "A change to the flow metadata, not including metadata_version, last_update or segments, results in a new version. If the metadata_version for flow instances is identical then the metadata is identical.",
       "type": "string"
     },
     "generation": {

--- a/api/schemas/flow-segment.json
+++ b/api/schemas/flow-segment.json
@@ -25,8 +25,7 @@
     },
     "sample_offset": {
       "description": "The start of the segment represented as a count of samples from the start of the object. Note that a sample is a video frame or audio sample. A (coded) audio frame has multiple audio samples",
-      "type": "integer",
-      "default": 0
+      "type": "integer"
     },
     "sample_count": {
       "description": "The count of samples in the segment (which may be fewer than in the object). The count could be less than expected given the segment duration and rate if there are gaps. If not set, every sample from sample_offset onwards is used. Note that a sample is a video frame or audio sample. A (coded) audio frame has multiple audio samples",

--- a/api/schemas/flow-video.json
+++ b/api/schemas/flow-video.json
@@ -40,7 +40,8 @@
                             "properties": {
                                 "numerator": {
                                     "description": "numerator",
-                                    "type": "integer"
+                                    "type": "integer",
+                                    "exclusiveMinimum": 0
                                 },
                                 "denominator": {
                                     "description": "denominator",
@@ -51,15 +52,18 @@
                         },
                         "frame_width": {
                             "description": "The width of the picture in pixels.",
-                            "type": "integer"
+                            "type": "integer",
+                            "exclusiveMinimum": 0
                         },
                         "frame_height": {
                             "description": "The height of the picture in pixels.",
-                            "type": "integer"
+                            "type": "integer",
+                            "exclusiveMinimum": 0
                         },
                         "bit_depth": {
                             "description": "The number of significant bits used to represent the video component sample.",
-                            "type": "integer"
+                            "type": "integer",
+                            "exclusiveMinimum": 0
                         },
                         "interlace_mode": {
                             "description": "Interlaced video mode for frames in this Flow",
@@ -102,11 +106,13 @@
                             "properties": {
                                 "numerator": {
                                     "description": "numerator",
-                                    "type": "integer"
+                                    "type": "integer",
+                                    "exclusiveMinimum": 0
                                 },
                                 "denominator": {
                                     "description": "denominator",
-                                    "type": "integer"
+                                    "type": "integer",
+                                    "exclusiveMinimum": 0
                                 }
                             }
                         },
@@ -120,11 +126,13 @@
                             "properties": {
                                 "numerator": {
                                     "description": "numerator",
-                                    "type": "integer"
+                                    "type": "integer",
+                                    "exclusiveMinimum": 0
                                 },
                                 "denominator": {
                                     "description": "denominator",
-                                    "type": "integer"
+                                    "type": "integer",
+                                    "exclusiveMinimum": 0
                                 }
                             }
                         },
@@ -138,11 +146,15 @@
                         },
                         "horiz_chroma_subs": {
                             "description": "Horizontal chroma component sub-sampling.",
-                            "type": "integer"
+                            "type": "integer",
+                            "exclusiveMinimum": 0,
+                            "maximum": 2
                         },
                         "vert_chroma_subs": {
                             "description": "Vertical chroma component sub-sampling.",
-                            "type": "integer"
+                            "type": "integer",
+                            "exclusiveMinimum": 0,
+                            "maximum": 2
                         },
                         "unc_parameters": {
                             "type": "object",

--- a/api/schemas/flow-video.json
+++ b/api/schemas/flow-video.json
@@ -146,12 +146,12 @@
                         "horiz_chroma_subs": {
                             "description": "Horizontal chroma component sub-sampling. When unc_type is set to a YUV type, horiz_chroma_subs must be set.",
                             "type": "integer",
-                            "minimum": 0
+                            "exclusiveMinimum": 0
                         },
                         "vert_chroma_subs": {
                             "description": "Vertical chroma component sub-sampling. When unc_type is set to a YUV type, vert_chroma_subs must be set.",
                             "type": "integer",
-                            "minimum": 0
+                            "exclusiveMinimum": 0
                         },
                         "unc_parameters": {
                             "type": "object",

--- a/api/schemas/flow-video.json
+++ b/api/schemas/flow-video.json
@@ -32,7 +32,7 @@
                     "additionalProperties": false,
                     "properties": {
                         "frame_rate": {
-                            "description": "The fixed number of frames per second.",
+                            "description": "The fixed number of frames per second. If this parameter is unset, the frame_rate is either unknown or variable.",
                             "type": "object",
                             "required": [
                                 "numerator"
@@ -46,7 +46,8 @@
                                 "denominator": {
                                     "description": "denominator",
                                     "type": "integer",
-                                    "default": 1
+                                    "default": 1,
+                                    "exclusiveMinimum": 0
                                 }
                             }
                         },
@@ -145,14 +146,12 @@
                         "horiz_chroma_subs": {
                             "description": "Horizontal chroma component sub-sampling. When unc_type is set to a YUV type, horiz_chroma_subs must be set.",
                             "type": "integer",
-                            "exclusiveMinimum": 0,
-                            "maximum": 2
+                            "minimum": 0
                         },
                         "vert_chroma_subs": {
                             "description": "Vertical chroma component sub-sampling. When unc_type is set to a YUV type, vert_chroma_subs must be set.",
                             "type": "integer",
-                            "exclusiveMinimum": 0,
-                            "maximum": 2
+                            "minimum": 0
                         },
                         "unc_parameters": {
                             "type": "object",

--- a/api/schemas/flow-video.json
+++ b/api/schemas/flow-video.json
@@ -68,7 +68,6 @@
                         "interlace_mode": {
                             "description": "Interlaced video mode for frames in this Flow",
                             "type": "string",
-                            "default": "progressive",
                             "enum": [
                                 "progressive",
                                 "interlaced_tff",
@@ -89,7 +88,6 @@
                         "transfer_characteristic": {
                             "description": "Transfer characteristic",
                             "type": "string",
-                            "default": "SDR",
                             "enum": [
                                 "SDR",
                                 "HLG",

--- a/api/schemas/flow-video.json
+++ b/api/schemas/flow-video.json
@@ -61,7 +61,7 @@
                             "exclusiveMinimum": 0
                         },
                         "bit_depth": {
-                            "description": "The number of significant bits used to represent the video component sample.",
+                            "description": "The number of significant bits used to represent the video component sample. If codec is `video/raw`, bit_depth must be set.",
                             "type": "integer",
                             "exclusiveMinimum": 0
                         },
@@ -145,13 +145,13 @@
                             ]
                         },
                         "horiz_chroma_subs": {
-                            "description": "Horizontal chroma component sub-sampling.",
+                            "description": "Horizontal chroma component sub-sampling. When unc_type is set to a YUV type, horiz_chroma_subs must be set.",
                             "type": "integer",
                             "exclusiveMinimum": 0,
                             "maximum": 2
                         },
                         "vert_chroma_subs": {
-                            "description": "Vertical chroma component sub-sampling.",
+                            "description": "Vertical chroma component sub-sampling. When unc_type is set to a YUV type, vert_chroma_subs must be set.",
                             "type": "integer",
                             "exclusiveMinimum": 0,
                             "maximum": 2
@@ -164,7 +164,7 @@
                             ],
                             "properties": {
                                 "unc_type": {
-                                    "description": "Uncompressed picture packing type.",
+                                    "description": "Uncompressed picture packing type. If codec is `video/raw`, unc_type must be set.",
                                     "type": "string",
                                     "enum": [
                                         "planar",

--- a/api/schemas/tags.json
+++ b/api/schemas/tags.json
@@ -2,9 +2,7 @@
     "title": "Tags",
     "description": "Key value is a freeform string.",
     "type": "object",
-    "patternProperties": {
-        "": {
+    "additionalProperties": {
             "type": "string"
-        }
     }
 }


### PR DESCRIPTION
# Details
This PR is the result of an audit of response codes and schema's. This PR:
* Removes 400 responses from queries which cannot return them
* Adds 400 responses to queries that can return them but were missing them
* Adds 404 responses for invalid path parameters
  * 404 is used here because invalid path parameters mean the path doesn't match the path pattern in the spec and, thus, the path is not found
* Adds minimum and maximum values to numeric parameters in the json schemas where sensible
  * Note that in all these cases, negative or zero values are nonsensical. These minimum/maximums reflect what would already be considered bugs in implementations.
* Adds notes in parameter descriptions indicating where one parameter is required based on the value of another
* Removes defaults in json schemas which cause unexpected behaviour in machine-generated implementations
* Expand some descriptions
* Adds missing schemas for flow tags endpoints
* Uses `additionalProperties` instead of `patternProperties` for tags schema to provide better rendered documentation, and better support machine-generated implementations

# Pivotal Story (if relevant)
Story URL: https://www.pivotaltracker.com/story/show/187691389

# Related PRs
_Where appropriate. Indicate order to be merged._

# Submitter PR Checks
_(tick as appropriate)_

- [ ] PR completes task/fixes bug
- [ ] API version has been incremented if necessary
- [ ] ADR status has been updated, and ADR implementation has been recorded
- [ ] Documentation updated (README, etc.)
- [ ] PR added to Pivotal story (if relevant)
- [ ] Follow-up stories added to Pivotal

# Reviewer PR Checks
_(tick as appropriate)_

- [ ] PR completes task/fixes bug
- [ ] Design makes sense, and fits with our current code base
- [ ] Code is easy to follow
- [ ] PR size is sensible
- [ ] Commit history is sensible and tidy

# Info on PRs
The checks above are guidelines. They don't all have to be ticked, but they should all have been considered.
