### PR TITLE
Fix the container mapping JSON schema pattern for SMPTE UMID

### DIFF
--- a/api/schemas/container-mapping.json
+++ b/api/schemas/container-mapping.json
@@ -48,9 +48,9 @@
             "type": "object",
             "properties": {
                 "package_uid": {
-                    "description": "The package UID. Either a UMID URN or UUID URN",
+                    "description": "The package UID. Either a SMPTE UMID URN or UUID URN",
                     "type": "string",
-                    "pattern": "^urn:smpte:umid:[0-9a-fA-F]{8}-[0-9a-fA-F]{8}-[0-9a-fA-F]{8}-[0-9a-fA-F]{8}$|^urn:uuid:[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$"
+                    "pattern": "^urn:smpte:umid:[0-9a-fA-F]{8}(.[0-9a-fA-F]{8}){7}$|^urn:uuid:[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$"
                 },
                 "track_id": {
                     "description": "The track ID in the package",


### PR DESCRIPTION
# Details
E.g. it's has a format such as `urn:smpte:umid:060a2b34.01010105.01010f20.13000000.3f1c42fd.dff941cf.89216ca3.a378ec9e`

# Pivotal Story (if relevant)
Story URL: https://www.pivotaltracker.com/story/show/187772636

# Related PRs
_Where appropriate. Indicate order to be merged._

# Submitter PR Checks
_(tick as appropriate)_

- [ ] PR completes task/fixes bug
- [ ] API version has been incremented if necessary
- [ ] ADR status has been updated, and ADR implementation has been recorded
- [ ] Documentation updated (README, etc.)
- [ ] PR added to Pivotal story (if relevant)
- [ ] Follow-up stories added to Pivotal

# Reviewer PR Checks
_(tick as appropriate)_

- [ ] PR completes task/fixes bug
- [ ] Design makes sense, and fits with our current code base
- [ ] Code is easy to follow
- [ ] PR size is sensible
- [ ] Commit history is sensible and tidy

# Info on PRs
The checks above are guidelines. They don't all have to be ticked, but they should all have been considered.
