### PR TITLE
gha: trigger CI workflow after release to update API docs

### DIFF
--- a/.github/workflows/ci-workflow.yml
+++ b/.github/workflows/ci-workflow.yml
@@ -10,6 +10,11 @@ on:
     branches:
       - 'main'
 
+  workflow_run:
+    workflows: [Release Workflow]
+    types:
+      - completed
+
   workflow_dispatch:
     inputs:
       forceDocsUpload:


### PR DESCRIPTION
# Details
The `release` trigger didn't work because the release used the GITHUB_TOKEN and that will not create a new workflow run - see [Triggering a workflow from a workflow](https://docs.github.com/en/actions/using-workflows/triggering-a-workflow#triggering-a-workflow-from-a-workflow)

# Pivotal Story (if relevant)
Story URL: https://www.pivotaltracker.com/story/show/187836655

# Related PRs
_Where appropriate. Indicate order to be merged._

# Submitter PR Checks
_(tick as appropriate)_

- [ ] PR completes task/fixes bug
- [ ] API version has been incremented if necessary
- [ ] ADR status has been updated, and ADR implementation has been recorded
- [ ] Documentation updated (README, etc.)
- [ ] PR added to Pivotal story (if relevant)
- [ ] Follow-up stories added to Pivotal

# Reviewer PR Checks
_(tick as appropriate)_

- [ ] PR completes task/fixes bug
- [ ] Design makes sense, and fits with our current code base
- [ ] Code is easy to follow
- [ ] PR size is sensible
- [ ] Commit history is sensible and tidy

# Info on PRs
The checks above are guidelines. They don't all have to be ticked, but they should all have been considered.
