### PR TITLE
api: allow flow segment paging using opaque key

### DIFF
--- a/api/TimeAddressableMediaStore.yaml
+++ b/api/TimeAddressableMediaStore.yaml
@@ -1179,13 +1179,18 @@ paths:
           description: Filter on object identifier.
           schema:
             type: string
+        - name: timerange
+          in: query
+          description: Return only the results in the timerange specified.
+          schema:
+            $ref: 'schemas/timerange.json'
         - name: reverse_order
           in: query
           description: Return segments in reverse time order.
           schema:
             default: false
             type: boolean
-        - $ref: '#/components/parameters/trait_timerange_paged_timerange'
+        - $ref: '#/components/parameters/trait_resource_paged_key'
         - $ref: '#/components/parameters/trait_paged_limit'
       responses:
         "200":
@@ -1235,13 +1240,18 @@ paths:
           description: Filter on object identifier.
           schema:
             type: string
+        - name: timerange
+          in: query
+          description: Return only the results in the timerange specified.
+          schema:
+            $ref: 'schemas/timerange.json'
         - name: reverse_order
           in: query
           description: Return segments in reverse time order.
           schema:
             default: false
             type: boolean
-        - $ref: '#/components/parameters/trait_timerange_paged_timerange'
+        - $ref: '#/components/parameters/trait_resource_paged_key'
         - $ref: '#/components/parameters/trait_paged_limit'
       responses:
         "200":
@@ -1267,6 +1277,10 @@ paths:
               description: The items are returned in reverse order.
               schema:
                 type: boolean
+            X-Paging-NextKey:
+              description: Opaque string that can be supplied to the `page` query parameter to get the next page of results.
+              schema:
+                type: string
           content:
             application/json:
               schema:
@@ -1796,12 +1810,6 @@ components:
     trait_resource_info_head_404:
       description: Resource was not found.
   parameters:
-    trait_timerange_paged_timerange:
-      name: timerange
-      in: query
-      description: Return only the results in the timerange specified.
-      schema:
-        $ref: 'schemas/timerange.json'
     trait_paged_limit:
       name: limit
       in: query


### PR DESCRIPTION
# Details
Allow the next page link to include a "page" query parameter that allows the next page to be retrieved. If the TAMS implementations uses the "page" parameter then it will likely leave the "timerange" query parameter unchanged.

Marking this change as a feature rather than a breaking change because clients should be treating the query parameters of a page link as opaque (given that the "page" parameter is opaque and any potential relationship with the other parameters is unknown).

# Pivotal Story (if relevant)
Story URL: https://www.pivotaltracker.com/story/show/187930075

# Related PRs
_Where appropriate. Indicate order to be merged._

# Submitter PR Checks
_(tick as appropriate)_

- [ ] PR completes task/fixes bug
- [ ] API version has been incremented if necessary
- [ ] ADR status has been updated, and ADR implementation has been recorded
- [ ] Documentation updated (README, etc.)
- [ ] PR added to Pivotal story (if relevant)
- [ ] Follow-up stories added to Pivotal

# Reviewer PR Checks
_(tick as appropriate)_

- [ ] PR completes task/fixes bug
- [ ] Design makes sense, and fits with our current code base
- [ ] Code is easy to follow
- [ ] PR size is sensible
- [ ] Commit history is sensible and tidy

# Info on PRs
The checks above are guidelines. They don't all have to be ticked, but they should all have been considered.
