### PR TITLE
Add ADR for a query option to filter `get_urls`

### DIFF
--- a/.github/workflows/commit-check-workflow.yml
+++ b/.github/workflows/commit-check-workflow.yml
@@ -13,7 +13,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: ${{github.event.pull_request.commits}} # only checkout commits from this PR
-          ref: ${{ github.ref }}
+          ref: ${{ github.head_ref }}
 
       - name: Check PR commit messages don't start with 'FIXUP'
         run: "[ $(git log --grep '^FIXUP' | wc -c) -eq 0 ]"

--- a/api/TimeAddressableMediaStore.yaml
+++ b/api/TimeAddressableMediaStore.yaml
@@ -1519,7 +1519,7 @@ paths:
             generate a large number of pre-signed URLs for example.
           schema:
             type: string
-            pattern: ^[^,]*(,[^,]*)*$
+            pattern: ^([^,]+(,[^,]+)*)?$
         - $ref: '#/components/parameters/trait_resource_paged_key'
         - $ref: '#/components/parameters/trait_paged_limit'
       responses:
@@ -1621,7 +1621,7 @@ paths:
             generate a large number of pre-signed URLs for example.
           schema:
             type: string
-            pattern: ^[^,]*(,[^,]*)*$
+            pattern: ^([^,]+(,[^,]+)*)?$
         - $ref: '#/components/parameters/trait_resource_paged_key'
         - $ref: '#/components/parameters/trait_paged_limit'
       responses:

--- a/api/TimeAddressableMediaStore.yaml
+++ b/api/TimeAddressableMediaStore.yaml
@@ -1512,8 +1512,9 @@ paths:
           in: query
           description: |
             A comma separated list of labels of flow segment `get_urls` to include in the response.
+            Omitting `accept_get_urls` will result in all `get_urls` returned.
             A 'default' label selects URLs with a 'default' or no label.
-            An empty `accept_get_urls` results in an empty or no `get_urls` flow segment property in the response.
+            An empty `accept_get_urls` results in an empty or no `get_urls` in the response.
             Without `get_urls`, the response from the service could be substantially faster if it is not required to
             generate a large number of pre-signed URLs for example.
           schema:
@@ -1613,8 +1614,9 @@ paths:
           in: query
           description: |
             A comma separated list of labels of flow segment `get_urls` to include in the response.
+            Omitting `accept_get_urls` will result in all `get_urls` returned.
             A 'default' label selects URLs with a 'default' or no label.
-            An empty `accept_get_urls` results in an empty or no `get_urls` flow segment property in the response.
+            An empty `accept_get_urls` results in an empty or no `get_urls` in the response.
             Without `get_urls`, the response from the service could be substantially faster if it is not required to
             generate a large number of pre-signed URLs for example.
           schema:

--- a/api/TimeAddressableMediaStore.yaml
+++ b/api/TimeAddressableMediaStore.yaml
@@ -1513,8 +1513,8 @@ paths:
           description: |
             A comma separated list of labels of flow segment `get_urls` to include in the response.
             Omitting `accept_get_urls` will result in all `get_urls` returned.
-            A 'default' label selects URLs with a 'default' or no label.
             An empty `accept_get_urls` results in an empty or no `get_urls` in the response.
+            Flow segment `get_urls` with no label cannot be filtered for.
             Without `get_urls`, the response from the service could be substantially faster if it is not required to
             generate a large number of pre-signed URLs for example.
           schema:
@@ -1615,8 +1615,8 @@ paths:
           description: |
             A comma separated list of labels of flow segment `get_urls` to include in the response.
             Omitting `accept_get_urls` will result in all `get_urls` returned.
-            A 'default' label selects URLs with a 'default' or no label.
             An empty `accept_get_urls` results in an empty or no `get_urls` in the response.
+            Flow segment `get_urls` with no label cannot be filtered for.
             Without `get_urls`, the response from the service could be substantially faster if it is not required to
             generate a large number of pre-signed URLs for example.
           schema:

--- a/api/TimeAddressableMediaStore.yaml
+++ b/api/TimeAddressableMediaStore.yaml
@@ -1508,6 +1508,15 @@ paths:
           schema:
             default: false
             type: boolean
+        - name: accept_get_urls
+          in: query
+          description: |
+            A comma separated list of labels of flow segment `get_urls` to include in the response.
+            A 'default' label selects URLs with a 'default' or no label.
+            An empty `accept_get_urls` results in an empty or no `get_urls` flow segment property in the response.
+          schema:
+            type: string
+            pattern: ^[^,]*(,[^,]*)*$
         - $ref: '#/components/parameters/trait_resource_paged_key'
         - $ref: '#/components/parameters/trait_paged_limit'
       responses:
@@ -1598,6 +1607,15 @@ paths:
           schema:
             default: false
             type: boolean
+        - name: accept_get_urls
+          in: query
+          description: |
+            A comma separated list of labels of flow segment `get_urls` to include in the response.
+            A 'default' label selects URLs with a 'default' or no label.
+            An empty `accept_get_urls` results in an empty or no `get_urls` flow segment property in the response.
+          schema:
+            type: string
+            pattern: ^[^,]*(,[^,]*)*$
         - $ref: '#/components/parameters/trait_resource_paged_key'
         - $ref: '#/components/parameters/trait_paged_limit'
       responses:

--- a/api/TimeAddressableMediaStore.yaml
+++ b/api/TimeAddressableMediaStore.yaml
@@ -1514,7 +1514,7 @@ paths:
             A comma separated list of labels of flow segment `get_urls` to include in the response.
             Omitting `accept_get_urls` will result in all `get_urls` returned.
             An empty `accept_get_urls` results in an empty or no `get_urls` in the response.
-            Flow segment `get_urls` with no label cannot be filtered for.
+            Flow segment `get_urls` with no label cannot be filtered for; they will only be returned if `accept_get_urls` is omitted.
             Without `get_urls`, the response from the service could be substantially faster if it is not required to
             generate a large number of pre-signed URLs for example.
           schema:
@@ -1616,7 +1616,7 @@ paths:
             A comma separated list of labels of flow segment `get_urls` to include in the response.
             Omitting `accept_get_urls` will result in all `get_urls` returned.
             An empty `accept_get_urls` results in an empty or no `get_urls` in the response.
-            Flow segment `get_urls` with no label cannot be filtered for.
+            Flow segment `get_urls` with no label cannot be filtered for; they will only be returned if `accept_get_urls` is omitted.
             Without `get_urls`, the response from the service could be substantially faster if it is not required to
             generate a large number of pre-signed URLs for example.
           schema:

--- a/api/TimeAddressableMediaStore.yaml
+++ b/api/TimeAddressableMediaStore.yaml
@@ -1514,6 +1514,8 @@ paths:
             A comma separated list of labels of flow segment `get_urls` to include in the response.
             A 'default' label selects URLs with a 'default' or no label.
             An empty `accept_get_urls` results in an empty or no `get_urls` flow segment property in the response.
+            Without `get_urls`, the response from the service could be substantially faster if it is not required to
+            generate a large number of pre-signed URLs for example.
           schema:
             type: string
             pattern: ^[^,]*(,[^,]*)*$
@@ -1613,6 +1615,8 @@ paths:
             A comma separated list of labels of flow segment `get_urls` to include in the response.
             A 'default' label selects URLs with a 'default' or no label.
             An empty `accept_get_urls` results in an empty or no `get_urls` flow segment property in the response.
+            Without `get_urls`, the response from the service could be substantially faster if it is not required to
+            generate a large number of pre-signed URLs for example.
           schema:
             type: string
             pattern: ^[^,]*(,[^,]*)*$

--- a/api/schemas/flow-segment.json
+++ b/api/schemas/flow-segment.json
@@ -41,7 +41,7 @@
         ],
         "properties": {
           "label": {
-            "description": "Label identifying this URL",
+            "description": "Label identifying this URL. If the 'label' is not set then this URL can't be filtered for using the 'accept_get_urls' API query parameter.",
             "type": "string"
           },
           "url": {

--- a/docs/README.md
+++ b/docs/README.md
@@ -32,6 +32,7 @@ For more information on how we use ADRs, see [here](./adr/README.md).
 | [0020](./adr/0020-version-signalling.md)                           | Improving the signalling of the supported API version in implementations   |
 | [0021](./adr/0021-storage-label-format.md)                         | Options for `get_urls` labels on Flow Segments                             |
 | [0022](./adr/0022-flow-bit-rate-properties.md)                     | Definitions for Flow bit rate properties and additional properties         |
+| [0023](./adr/0023-filter-segment-get-urls.md)                      | Add query option to filter Flow Segment `get_urls` by `label`              |
 | [0025](./adr/0025-flow-property-updates.md)                        | Options for updating Flow properties                                       |
 
 \* Note: ADR 0004a was the unintended result of a number clash in the early development of TAMS which wasn't caught before publication

--- a/docs/adr/0023-filter-segment-get-urls.md
+++ b/docs/adr/0023-filter-segment-get-urls.md
@@ -1,0 +1,78 @@
+---
+status: "proposed"
+---
+# Query Option to Filter get_urls
+
+## Context and Problem Statement
+
+Each Flow Segment returned by the `/flows/<flow id>/segment` endpoint includes a `get_urls` propery that may include (labelled) URLs for fetching media objects.
+The calculation of pre-signed URLs for example can result in an not insignificant increased request time.
+Clients do not need the `get_urls` if they don't intend to fetch the media objects.
+This ADR proposes adding a query option to filter the URLs that need to be included by a TAMS.
+
+It was found that calculating a pre-signed URL for fetching a media object takes around 0.35 milliseconds when using the Python [boto3](https://github.com/boto/boto3) library.
+That means a request to get 5000 Flow Segments will include around 1.75 seconds overhead to calculate the pre-signed URLs.
+This was observed in a request to a TAMS which took around 4 seconds to return Flow Segments with pre-signed URLs and only around 2 seconds to return the same Flow Segments without pre-signed URLs.
+
+The [boto3](https://github.com/boto/boto3) method to generate pre-signed URLs could also be optimised to reduce the time taken.
+It was found that the older deprecated [boto](https://github.com/boto/boto) library took around 0.14 milliseconds to calculate a pre-signed URL, a 60% speed reduction when compared to [boto3](https://github.com/boto/boto3).
+There are likely even more optimisations that could be made.
+
+The pre-signed URL calculation may use a highly optimised implementation that avoids the large time overhead.
+This would still result in larger response sizes because the pre-signed URLs tend to be quite large as they include signatures, keys and tokens.
+
+It is difficult to predict what the expected number of flow segments will be in practice.
+If it is low in all cases then including or not including pre-signed URLs doesn't make much difference.
+If it is unknown then having an option to avoid the pre-signed calculation overhead may be useful in some cases.
+
+## Considered Options
+
+* Option 1: Always return all `get_urls`
+* Option 2: Add a query option to return none or all `get_urls`
+* Option 3: Add a simple query option to filter `get_urls` based on the `label`
+* Option 4: Add more complex query option(s) to filter `get_urls`
+
+## Decision Outcome
+
+Chosen option: "Option 3: Add a simple query option to filter `get_urls` based on the `label`", because this covers the requirement to disable calculation of pre-signed URLs and at the same time allows other URLs to be retained.
+
+### Implementation
+
+Implemented in [PR #88](https://github.com/bbc/tams/pull/88).
+
+## Pros and Cons of the Options
+
+### Option 1: Always return all `get_urls`
+
+This is the current state.
+
+* Bad, because TAMS is doing work to calculate pre-signed URLs even though clients may not need them
+
+### Option 2: Add a query option to return none or all `get_urls`
+
+This adds a boolean option named `include_get_urls` that if set to `false` results in no `get_urls` in the response and therefore no pre-signed URLs are calculated by TAMS.
+
+* Good, because it allows clients to indicate that `get_urls` are not required
+* Bad, because some TAMS implementations may provide different types of URLs and a client does not have the option to filter out the ones that cause increased request time whilst retaining ones that don't
+
+### Option 3: Add a simple query option to filter `get_urls` based on the `label`
+
+This extends [Option 2](#option-2-add-a-query-option-to-return-none-or-all-get_urls) to add a (comma-separated) list option named `accept_get_urls` that specifies the `labels` associated with URLS to include in the response.
+Omitting `accept_get_urls` will result in all URLs in the response.
+Setting `accept_get_urls` to an empty string will result in no URLs in the response.
+If `accept_get_urls` includes a `default` label then URLs with label `default` or no label are included in the response.
+
+* Good, because it allows clients to indicate that `get_urls` are not required
+* Good, because clients can retain URLs that don't cause increased request times
+* Neutral, because clients may want more complex filters based on what is available
+
+### Option 4: Add more complex query option(s) to filter `get_urls`
+
+This changes [Option 3](#option-3-add-a-simple-query-option-to-filter-get_urls-based-on-the-label) to allow more complex filtering based on what URLs are available.
+E.g. include a URL for direct access to the object if available and otherwise a pre-signed URL.
+
+* Good, because it allows clients to indicate that `get_urls` are not required
+* Good, because clients can retain URLs that don't cause increased request times
+* Neutral, because clients can use more complex filters based on what is available
+* Neutral, because it isn't clear whether there is a requirement for more complex filters
+* Neutral, because [0021](./0021-storage-label-format.md) thus far only proposes an App note for guidance on the use of `get_urls` labels on flow segments

--- a/docs/adr/0023-filter-segment-get-urls.md
+++ b/docs/adr/0023-filter-segment-get-urls.md
@@ -60,7 +60,7 @@ This adds a boolean option named `include_get_urls` that if set to `false` resul
 This extends [Option 2](#option-2-add-a-query-option-to-return-none-or-all-get_urls) to add a (comma-separated) list option named `accept_get_urls` that specifies the `labels` associated with URLS to include in the response.
 Omitting `accept_get_urls` will result in all URLs in the response.
 Setting `accept_get_urls` to an empty string will result in no URLs in the response.
-If `accept_get_urls` includes a `default` label then URLs with label `default` or no label are included in the response.
+Flow segment `get_urls` with no label cannot be filtered.
 
 * Good, because it allows clients to indicate that `get_urls` are not required
 * Good, because clients can retain URLs that don't cause increased request times

--- a/docs/adr/0023-filter-segment-get-urls.md
+++ b/docs/adr/0023-filter-segment-get-urls.md
@@ -5,7 +5,7 @@ status: "proposed"
 
 ## Context and Problem Statement
 
-Each Flow Segment returned by the `/flows/<flow id>/segment` endpoint includes a `get_urls` propery that may include (labelled) URLs for fetching media objects.
+Each Flow Segment returned by the `/flows/<flow id>/segment` endpoint includes a `get_urls` property that may include (labelled) URLs for fetching media objects.
 The calculation of pre-signed URLs for example can result in an not insignificant increased request time.
 Clients do not need the `get_urls` if they don't intend to fetch the media objects.
 This ADR proposes adding a query option to filter the URLs that need to be included by a TAMS.

--- a/docs/adr/0023-filter-segment-get-urls.md
+++ b/docs/adr/0023-filter-segment-get-urls.md
@@ -1,5 +1,5 @@
 ---
-status: "proposed"
+status: "accepted"
 ---
 # Query Option to Filter get_urls
 

--- a/docs/appnotes/0009-storage-label-format.md
+++ b/docs/appnotes/0009-storage-label-format.md
@@ -33,13 +33,14 @@ But they may provide multiple types of Object Storage.
 These may have vastly different properties.
 And there is often no universal naming conventions to describe these products in a way that is comparable between cloud providers.
 So while we need to signal this, we are not able to provide universal naming conventions.
+The storage type can optionally indicate whether the URLs are presigned or not.
 
 Finally, a more generic "store name" parameter is useful for human identification of stores, and for distinguishing stores which are otherwise identical.
 It should be noted that the logical concept of a named "store" in this case is distinct from a bucket (or equivalent concept).
 A "store" may make use of multiple buckets for performance reasons, for example.
 But the properties of buckets of a named store should be otherwise identical.
 
-In summary; we must signal storage provider, storage time, and store name.
+In summary; we must signal storage provider, storage type, and store name.
 However we may also need to add the optional parameters of region, and availability zone.
 We cannot, unfortunately, signal any of these in consistently named and universally comparable ways.
 But we can specify a schema which allows a client to consistently decide which pieces of information are important to it.
@@ -49,13 +50,13 @@ But we can specify a schema which allows a client to consistently decide which p
 Given all of the above, this Application Note recommends the following naming convention for the `get_urls` `label` parameter on flow segments:
 
 ```text
-<provider>.<region[optional]>.<availabilityZone[optional]>:<storeType>:<storeName>
+<provider>.<region[optional]>.<availabilityZone[optional]>:<storeType>.<presigned[optional]>:<storeName>
 ```
 
 This can be represented more formally with the following Python-compatible regex:
 
 ```regex
-^(?P<provider>[A-Za-z0-9\-\_]+)(.(?P<region>[A-Za-z0-9\-\_]+)(.(?P<availabilityZone>[A-Za-z0-9\-\_]+))?)?:(?P<storeType>[A-Za-z0-9\-\_]+):(?P<storeName>[A-Za-z0-9\-\_]+)$
+^(?P<provider>[A-Za-z0-9\-\_]+)(\.(?P<region>[A-Za-z0-9\-\_]+)(\.(?P<availabilityZone>[A-Za-z0-9\-\_]+))?)?:(?P<storeType>[A-Za-z0-9\-\_]+)(\.presigned)?:(?P<storeName>[A-Za-z0-9\-\_]+)$
 ```
 
 An example use of this would be:
@@ -74,6 +75,12 @@ An example use of this without a region would be:
 
 ```text
 example-cloud-provider:example-storage-product:example-store-name
+```
+
+An example use of this with presigned URLs would be:
+
+```text
+example-cloud-provider.eu-west-1.a:example-storage-product.presigned:example-store-name
 ```
 
 The parameters `provider`, `region`, `availabilityZone`, and `storeType` should use the machine readable values as provided by the cloud/storage vendor.


### PR DESCRIPTION
# Details
This PR adds an ADR that proposes a `accept_get_urls` query option to filter flow segment `get_urls`. This allows clients to indicate that pre-signed URLs are not required, potentially significantly reducing the request time when requesting a large number of flow segments.

# Pivotal Story (if relevant)
Story URL: https://www.pivotaltracker.com/story/show/187930100

# Related PRs
_Where appropriate. Indicate order to be merged._

# Submitter PR Checks
_(tick as appropriate)_

- [ ] PR completes task/fixes bug
- [ ] API version has been incremented if necessary
- [ ] ADR status has been updated, and ADR implementation has been recorded
- [ ] Documentation updated (README, etc.)
- [ ] PR added to Pivotal story (if relevant)
- [ ] Follow-up stories added to Pivotal

# Reviewer PR Checks
_(tick as appropriate)_

- [ ] PR completes task/fixes bug
- [ ] Design makes sense, and fits with our current code base
- [ ] Code is easy to follow
- [ ] PR size is sensible
- [ ] Commit history is sensible and tidy

# Info on PRs
The checks above are guidelines. They don't all have to be ticked, but they should all have been considered.
