### PR TITLE
api: An empty timerange filters flows with no content

### DIFF
--- a/api/TimeAddressableMediaStore.yaml
+++ b/api/TimeAddressableMediaStore.yaml
@@ -710,7 +710,7 @@ paths:
             $ref: '#/components/schemas/uuid'
         - name: timerange
           in: query
-          description: Filter on flows that overlap the given timerange.
+          description: Filter on flows that overlap the given timerange. An empty timerange returns flows with no content.
           schema:
             default: _
             $ref: 'schemas/timerange.json'


### PR DESCRIPTION
# Details
This PR makes filtering using a empty timerange more useful by specifying that TAMS in that case should return flows that have no content.

# Pivotal Story (if relevant)
Story URL: https://www.pivotaltracker.com/story/show/188190520

# Related PRs
_Where appropriate. Indicate order to be merged._

# Submitter PR Checks
_(tick as appropriate)_

- [ ] PR completes task/fixes bug
- [ ] API version has been incremented if necessary
- [ ] ADR status has been updated, and ADR implementation has been recorded
- [ ] Documentation updated (README, etc.)
- [ ] PR added to Pivotal story (if relevant)
- [ ] Follow-up stories added to Pivotal

# Reviewer PR Checks
_(tick as appropriate)_

- [ ] PR completes task/fixes bug
- [ ] Design makes sense, and fits with our current code base
- [ ] Code is easy to follow
- [ ] PR size is sensible
- [ ] Commit history is sensible and tidy

# Info on PRs
The checks above are guidelines. They don't all have to be ticked, but they should all have been considered.
