### PR TITLE
Remove ambiguity in re-used `collection-item` description

### DIFF
--- a/api/schemas/collection-item.json
+++ b/api/schemas/collection-item.json
@@ -8,7 +8,7 @@
     ],
     "properties": {
         "id": {
-            "description": "Source or Flow Identifier of the member of this collection.  Must already be registered in TAMS",
+            "description": "Source or Flow Identifier of the member of this collection. Sources must only collect Sources, and Flows must only collect Flows. Must already be registered in TAMS",
             "type": "string",
             "pattern": "^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$"
         },


### PR DESCRIPTION
# Details
Remove ambiguity in re-used `collection-item` description. While the parent item description which made use of this re-usable object specified that Flows collect Flows, and Sources collect Sources - this description could be seen as being in conflict. This change fixes that.

# Pivotal Story (if relevant)
Story URL:

# Related PRs
_Where appropriate. Indicate order to be merged._

# Submitter PR Checks
_(tick as appropriate)_

- [ ] PR completes task/fixes bug
- [ ] API version has been incremented if necessary
- [ ] ADR status has been updated, and ADR implementation has been recorded
- [ ] Documentation updated (README, etc.)
- [ ] PR added to Pivotal story (if relevant)
- [ ] Follow-up stories added to Pivotal

# Reviewer PR Checks
_(tick as appropriate)_

- [ ] PR completes task/fixes bug
- [ ] Design makes sense, and fits with our current code base
- [ ] Code is easy to follow
- [ ] PR size is sensible
- [ ] Commit history is sensible and tidy

# Info on PRs
The checks above are guidelines. They don't all have to be ticked, but they should all have been considered.
