### PR TITLE
Fix commit check checkout ref

### DIFF
--- a/.github/workflows/commit-check-workflow.yml
+++ b/.github/workflows/commit-check-workflow.yml
@@ -13,7 +13,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: ${{github.event.pull_request.commits}} # only checkout commits from this PR
-          ref: ${{ github.ref }}
+          ref: ${{ github.head_ref }}
 
       - name: Check PR commit messages don't start with 'FIXUP'
         run: "[ $(git log --grep '^FIXUP' | wc -c) -eq 0 ]"


### PR DESCRIPTION
# Details
Using `github.ref` resulted in `fetch-depth` number of commits from the `main` branch. This resulted in a commit check failure because of an earlier [commit](https://github.com/bbc/tams/commit/0e6712106a219491d0a4f203f54c3bb21ff95e98) that had the word SQUASH in it.

# Jira Issue (if relevant)
Jira URL:

# Related PRs
_Where appropriate. Indicate order to be merged._

# Submitter PR Checks
_(tick as appropriate)_

- [ ] PR completes task/fixes bug
- [ ] API version has been incremented if necessary
- [ ] ADR status has been updated, and ADR implementation has been recorded
- [ ] Documentation updated (README, etc.)
- [ ] PR added to Jira Issue (if relevant)
- [ ] Follow-up stories added to Jira

# Reviewer PR Checks
_(tick as appropriate)_

- [ ] PR completes task/fixes bug
- [ ] Design makes sense, and fits with our current code base
- [ ] Code is easy to follow
- [ ] PR size is sensible
- [ ] Commit history is sensible and tidy

# Info on PRs
The checks above are guidelines. They don't all have to be ticked, but they should all have been considered.
