### PR TITLE
Updates to Webhook events and filtering

### DIFF
--- a/api/TimeAddressableMediaStore.yaml
+++ b/api/TimeAddressableMediaStore.yaml
@@ -2001,10 +2001,7 @@ webhooks:
             schema:
               title: Flow Segments Added
               description: |
-                Notification that new segments have been added to a Flow. The message body contains the timerange
-                covered by the new segments, however implementations MAY rate limit these messages and provide a single
-                message covering multiple segments. The timerange in the message MUST intersect with a segment at both
-                start and end (e.g. it cannot start or end in empty space).
+                Notification that new segments have been added to a Flow.
               required:
                 - event_timestamp
                 - event_type
@@ -2021,12 +2018,14 @@ webhooks:
                   type: object
                   required:
                     - flow_id
-                    - timerange
+                    - segments
                   properties:
                     flow_id:
                       $ref: "#/components/schemas/uuid"
-                    timerange:
-                      $ref: 'schemas/timerange.json'
+                    segments:
+                      type: array
+                      items:
+                        $ref: 'schemas/flow-segment.json'
   flows/segments_deleted:
     post:
       security:
@@ -2037,10 +2036,7 @@ webhooks:
             schema:
               title: Flow Segments Deleted
               description: |
-                Notification that segments have been deleted from a Flow. The message body contains the timerange over
-                which segments have been deleted, however implementations MAY rate limit these messages and provide a
-                single message covering multiple segments. The timerange in the message MUST intersect with a segment
-                which has been deleted at both start and end (e.g. it cannot start or end in empty space).
+                Notification that segments have been deleted from a Flow.
               required:
                 - event_timestamp
                 - event_type
@@ -2062,6 +2058,7 @@ webhooks:
                     flow_id:
                       $ref: "#/components/schemas/uuid"
                     timerange:
+                      description: The timerange of segments that have been deleted. The timerange MUST intersect with a segment which has been deleted at both start and end (e.g. it cannot start or end in empty space).
                       $ref: 'schemas/timerange.json'
   sources/created:
     post:

--- a/api/TimeAddressableMediaStore.yaml
+++ b/api/TimeAddressableMediaStore.yaml
@@ -175,6 +175,9 @@ paths:
 
         HTTP requests from the service SHOULD include a `api_key_name` header with the 'api_key_value' value. Clients SHOULD verify this against the value they provided when registering the webhook.
 
+        API implementations MAY partially support event filtering and transformations.
+        API implementations SHALL return a 400 response code if the filtering or transformation specified in the request is not supported.
+
         API implementations SHOULD consider the security implementations of providing webhooks, and include appropriate
         mitigations against Server Side Request Forgery (SSRF) attacks and similar.
       operationId: POST_webhooks
@@ -199,7 +202,7 @@ paths:
         "204":
           description: Success. The webhook has been removed
         "400":
-          description: Bad request. Invalid parameters.
+          description: Bad request. Invalid parameters or unsupported event filtering or transformation.
         "404":
           description: "Webhooks are not supported by this API implementation"
   /sources:

--- a/api/schemas/webhook-post.json
+++ b/api/schemas/webhook-post.json
@@ -57,6 +57,13 @@
                 "type": "string",
                 "pattern": "^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$"
             }
+        },
+        "accept_get_urls": {
+            "description": "List of labels of URLs to include in the `get_urls` property in `flows/segments_added` events. This option is the same as the `accept_get_urls` query parameter for the /flows/{flowId}/segments API endpoint, except that the labels are represented using a JSON array rather than a (comma separated list) string.",
+            "type": "array",
+            "items": {
+                "type": "string"
+            }
         }
     }
 }

--- a/api/schemas/webhook-post.json
+++ b/api/schemas/webhook-post.json
@@ -27,7 +27,7 @@
             }
         },
         "flow_ids": {
-            "description": "Limit Flow related events to the given list of Flow IDs. Non-Flow related events are not affected",
+            "description": "Limit Flow and Flow Segment events to Flows in the given list of Flow IDs",
             "type": "array",
             "items": {
                 "type": "string",
@@ -35,7 +35,23 @@
             }
         },
         "source_ids": {
-            "description": "Limit Source related events to the given list of Source IDs. Non-Source related events are not affected",
+            "description": "Limit Flow, Flow Segment and Source events to Sources in the given list of Source IDs",
+            "type": "array",
+            "items": {
+                "type": "string",
+                "pattern": "^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$"
+            }
+        },
+        "flow_collected_by_ids": {
+            "description": "Limit Flow and Flow Segment events to those with Flow that is collected by a Flow Collection in the given list of Flow Collection IDs",
+            "type": "array",
+            "items": {
+                "type": "string",
+                "pattern": "^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$"
+            }
+        },
+        "source_collected_by_ids": {
+            "description": "Limit Flow, Flow Segment and Source events to those with Source that is collected by a Source Collection in the given list of Source Collection IDs",
             "type": "array",
             "items": {
                 "type": "string",

--- a/api/schemas/webhook.json
+++ b/api/schemas/webhook.json
@@ -57,6 +57,13 @@
                 "type": "string",
                 "pattern": "^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$"
             }
+        },
+        "accept_get_urls": {
+            "description": "List of labels of URLs to include in the `get_urls` property in `flows/segments_added` events. This option is the same as the `accept_get_urls` query parameter for the /flows/{flowId}/segments API endpoint, except that the labels are represented using a JSON array rather than a (comma separated list) string.",
+            "type": "array",
+            "items": {
+                "type": "string"
+            }
         }
     }
 }

--- a/api/schemas/webhook.json
+++ b/api/schemas/webhook.json
@@ -27,7 +27,7 @@
             }
         },
         "flow_ids": {
-            "description": "Limit Flow related events to the given list of Flow IDs. Non-Flow related events are not affected",
+            "description": "Limit Flow and Flow Segment events to Flows in the given list of Flow IDs",
             "type": "array",
             "items": {
                 "type": "string",
@@ -35,7 +35,23 @@
             }
         },
         "source_ids": {
-            "description": "Limit Source related events to the given list of Source IDs. Non-Source related events are not affected",
+            "description": "Limit Flow, Flow Segment and Source events to Sources in the given list of Source IDs",
+            "type": "array",
+            "items": {
+                "type": "string",
+                "pattern": "^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$"
+            }
+        },
+        "flow_collected_by_ids": {
+            "description": "Limit Flow and Flow Segment events to those with Flow that is collected by a Flow Collection in the given list of Flow Collection IDs",
+            "type": "array",
+            "items": {
+                "type": "string",
+                "pattern": "^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$"
+            }
+        },
+        "source_collected_by_ids": {
+            "description": "Limit Flow, Flow Segment and Source events to those with Source that is collected by a Source Collection in the given list of Source Collection IDs",
             "type": "array",
             "items": {
                 "type": "string",

--- a/docs/README.md
+++ b/docs/README.md
@@ -35,6 +35,7 @@ For more information on how we use ADRs, see [here](./adr/README.md).
 | [0023](./adr/0023-filter-segment-get-urls.md)                      | Add query option to filter Flow Segment `get_urls` by `label`              |
 | [0024](./adr/0024-source-level-edit.md)                            | Source-level Edit                                                          |
 | [0025](./adr/0025-flow-property-updates.md)                        | Options for updating Flow properties                                       |
+| [0026](./adr/0026-updated-webhook-events-and-filters.md)           | Updates to the webhook event structures and filters                        |
 
 \* Note: ADR 0004a was the unintended result of a number clash in the early development of TAMS which wasn't caught before publication
 

--- a/docs/adr/0026-updated-webhook-events-and-filters.md
+++ b/docs/adr/0026-updated-webhook-events-and-filters.md
@@ -62,6 +62,8 @@ Note that a TAMS implementation may limit the information returned in events, e.
 
 The `timerange` property is removed from the `flows/segments_added` event as that information is now available in the union of `timerange` properties in the `segments`.
 
+See the [More Information](#more-information) section for filtering guidelines and use cases.
+
 * Good, because it fulfills the known user requirements
 * Good, because it extends the current specifiction rather than being a complete overhaul
 * Neutral, because it requires an extra query to get the Flow Collection IDs (Flow's `collected_by` property) associated with the Flow
@@ -77,6 +79,8 @@ The `source_collected_by_ids` filter option is added to the webhook registration
 The property lists the Source Collections that collect the Source in the `collected_by` property.
 The Source in the Flow and Flow Segment event case is the Source referenced by the Flow's `source_id` property.
 
+See the [More Information](#more-information) section for filtering guidelines and use cases.
+
 * Good, because it provides a filtering capability at the Source level
 * Good, because new Flows or Sources in a collection wouldn't require changes to the webhook registration
 * Neutral, because it requires an extra query to get the Source Collection IDs (Source's `collected_by` property) associated with the Flow's Source
@@ -91,22 +95,35 @@ This requires the event processing pipeline to transform the `segments` in the F
 
 ## More Information
 
-### Event filter logic
+### Event filter guidelines
+
+The events can be filtered by associated Flows, Sources, Flow Collections and Source Collections.
+The following properties are needed by the filter process for Flow and Flow Segment events (the name used here is structured as `{entity}.{property}`):
+
+* `Flow.id`: the ID of the Flow.
+* `Flow.collected_by`: the IDs of the Flow Collections that collect the Flow.
+* `Source.id`: the ID of the Flow's Source.
+The property value equals `Flow.source_id`.
+* `Source.collected_by`: the IDs of the Source Collections that collect the Flow's Source.
+
+The following properties are needed by the filter process for Source events:
+
+* `Source.id`: the ID of the Source.
+* `Source.collected_by`: the IDs of the Source Collections that collect the Source.
 
 The `events` webhook property lists the event types that are passed through the filter.
 The `events` cannot be empty as an empty events is used to delete the webhook.
 
-If `flow_ids` is set then Flow and Flow Segment events are only passed through if they refer directly to a Flow in the `flow_ids` list.
+If the `flow_ids` webhook property is set then Flow and Flow Segment events are only passed through if the `Flow.id` is in the `flow_ids` list.
 The `flows_ids` has no filter effect if not set or for Source events.
 
-If `source_ids` is set then Flow, Flow Segment and Source events are only passed through if they refer directly to a Source in the `source_ids` list.
+If the `source_ids` webhook property is set then Flow, Flow Segment and Source events are only passed through if the `Source.id` is in the `source_ids` list.
 The `source_ids` has no filter effect if not set.
 
-If `flow_collected_by_ids` is set then Flow and Flow Segment events are only passed through if they are `collected_by` a Flow Collection in the `flow_collected_by_ids` list.
+If the `flow_collected_by_ids` webhook property is set then Flow and Flow Segment events are only passed through if there is an ID in the `Flow.collected_by` list that is also in the `flow_collected_by_ids` list.
 The `flow_collected_by_ids` has no filter effect if not set or for Source events.
 
-If `source_collected_by_ids` is set then Flow, Flow Segment and Source events are only passed through if they collected by a Source Collection in the `source_collected_by_ids` list.
-The Flow is collected by a Source Collection if the Source referenced by the Flow is collected by the Source Collection.
+If the `source_collected_by_ids` webhook property is set then Flow, Flow Segment and Source events are only passed through if there is an ID in the `Source.collected_by` list that is also in the `source_collected_by_ids` list.
 The `source_collected_by_ids` has no filter effect if not set.
 
 ### Some use cases and associated webhook options

--- a/docs/adr/0026-updated-webhook-events-and-filters.md
+++ b/docs/adr/0026-updated-webhook-events-and-filters.md
@@ -1,0 +1,167 @@
+---
+status: "proposed"
+---
+# Updated Webhook Events and Filters
+
+## Context and Problem Statement
+
+TAMS includes an endpoint to register webhooks for receiving Flow, Flow Segment and Source events.
+The API specification for the webhook was intended to provide an example of a basic webhook with filtering capabilities.
+It was assumed that developers would implement and use the basic webhook that is available in implementations and that later iterations of the TAMS specification would incorporate changes based on learnings and to better match real-world requirements.
+
+The webhook as specified was found to be useful to users of the current set of TAMS implementations, but they have asked for some updates.
+This ADR proposes some updates to the webhook specification in TAMS.
+
+## Decision Drivers
+
+* Users have asked to filter on Flow Collections such that all events associated with Flows in the collection are included.
+This avoids needing to query the list of Flows in the collection when registerering the webhook.
+This allows new Flows to be added to the collection without requiring a new webhook with updated filters to be registered, avoiding disruption to the event streams.
+* Users have asked to be able to filter Flow and Flow Segment events by Source ID.
+* Similar to filtering on Flow Collection, it would be useful to be able to filter Flow and Flow Segment events by Source Collections as well.
+* Users have asked to have the Flow Segment events contain the same information that is present in the API endpoint response.
+This avoids needing additional API queries to get the missing information.
+* Users have asked to be able to filter the `get_urls` in Flow Segments in the same way that is currently possible in API endpoint requests.
+
+## Considered Options
+
+* Option 1: Leave the webhook specification unchanged
+* Option 2a: Make the event filter and complete Flow Segment information requested by users
+* Option 2b: Extend option 2a to add support for filtering by Source Collections
+* Option 3: Make the event transformation updates requested by users
+
+## Decision Outcome
+
+Chosen option: Option 2b, because that provides most of what users have explicitly requested.
+Also, filtering on Source Collections is likely to be needed in systems that operate on Sources.
+The assumption is that the extra queries to get the Flow and Source Collection IDs is worth the benefits of having more advanced event filtering on collections.
+
+Option 3 requires additional event processing to transform events for webhook endpoints.
+It is unclear whether the additional processing warrants specification at this time.
+
+There may be other ways to achieve a requirement to include or not include presigned `get_urls` in Flow Segments.
+
+* A TAMS implementation may include a configure option to enable inclusion of presigned URLs.
+* A Flow tag may be used to indicate where Flow Segment events should include presigned URLs.
+An application that requires presigned URLs for performance reasons (e.g. to avoid an API request) can decide to enable it for the Flows it creates.
+A permissions system sitting in front of a TAMS could decide whether users can enable presigned URLs for Flows using the tag.
+
+### Implementation
+
+Specification changes have been implemented in PR [#105](https://github.com/bbc/tams/pull/105).
+
+## Pros and Cons of the Options
+
+### Option 1: Leave the webhook specification unchanged
+
+* Good, because it avoids making breaking changes to the specification
+* Good, because it has been proven to work using existing implementations
+* Bad, because it doesn't fulfill known user requirements which may lead to future divergence in implementations to meet those requirements
+
+### Option 2a: Make the event filter and complete Flow Segment information requested by users
+
+The `flow_ids` and `source_ids` filter option in the webhook registration now refer to just the Flow and/or Source entity directly associated with the event.
+The Flow and Flow Segment events have a Flow (Flow `id` property) and Source (Flow `source_id` property) directly associated with it.
+Note that the Flows and Sources could be collection Flows and Sources.
+
+The `flow_collected_by_ids` filter option in the webhook registration refers to the Flow Collections referenced through the Flow `collected_by` property.
+
+The `flows/segments_added` event is changed to add a `segments` property and remove the `timerange` property.
+The `segments` property that contains a list of Flow Segment data structures that contain the same information as returned by the segments API endpoint.
+Note that a TAMS implementation may limit the information returned in events, e.g. omit the presigned `get_urls` for security reasons.
+
+The `timerange` property is removed from the `flows/segments_added` event as that information is now available in the union of `timerange` properties in the `segments`.
+
+* Good, because it fulfills the known user requirements
+* Good, because it extends the current specifiction rather than being a complete overhaul
+* Neutral, because it requires an extra query to get the Flow Collection IDs (Flow's `collected_by` property) associated with the Flow
+* Neutral, because more information is included in Flow Segment events which may increase the transmission and processing costs
+* Neutral, because including presigned URLs in the Flow Segment information may compromise security as the webhook receiver is not directly involved in the authentication process
+
+### Option 2b: Extend option 2a to add support for filtering by Source Collections
+
+A system that prefers dealing with Sources rather than Flows would benefit from the ability to filter events based on Source Collections.
+A filter based on Source Collections would also support additions to the underlying Flows without requiring the webhook to be re-registered with an updated list of Flows to filter on.
+
+The `source_collected_by_ids` filter option is added to the webhook registration.
+The property lists the Source Collections that collect the Source in the `collected_by` property.
+The Source in the Flow and Flow Segment event case is the Source referenced by the Flow's `source_id` property.
+
+* Good, because it provides a filtering capability at the Source level
+* Good, because new Flows or Sources in a collection wouldn't require changes to the webhook registration
+* Neutral, because it requires an extra query to get the Source Collection IDs (Source's `collected_by` property) associated with the Flow's Source
+
+### Option 3: Make the event transformation updates requested by users
+
+The webhook options could be extended with a `accept_get_urls` property that functions the same way as the query parameter on the segment access API endpoint.
+This requires the event processing pipeline to transform the `segments` in the Flow Segment events by filtering the Flow Segment `get_urls` using the value set in `accept_get_urls`.
+
+A `segment_timerange_only` webhook option could be used to reduce the size of Flow Segment events by returning just a `timerange` rather than the `segments`.
+
+* Good, because it provides some control to webhook users of how much information is sent, which may help reduce transmission and processing costs.
+* Bad, because it requires additional processing in the event transmission pipeline to transform the events
+
+## More Information
+
+### Event filter logic
+
+The `events` webhook property lists the event types that are passed through the filter.
+The `events` cannot be empty as an empty events is used to delete the webhook.
+
+If `flow_ids` is set then Flow and Flow Segment events are only passed through if they refer directly to a Flow in the `flow_ids` list.
+The `flows_ids` has no filter effect if not set or for Source events.
+
+If `source_ids` is set then Flow, Flow Segment and Source events are only passed through if they refer directly to a Source in the `source_ids` list.
+The `source_ids` has no filter effect if not set.
+
+If `flow_collected_by_ids` is set then Flow and Flow Segment events are only passed through if they are `collected_by` a Flow Collection in the `flow_collected_by_ids` list.
+The `flow_collected_by_ids` has no filter effect if not set or for Source events.
+
+If `source_collected_by_ids` is set then Flow, Flow Segment and Source events are only passed through if they collected by a Source Collection in the `source_collected_by_ids` list.
+The Flow is collected by a Source Collection if the Source referenced by the Flow is collected by the Source Collection.
+The `source_collected_by_ids` has no filter effect if not set.
+
+### Some use cases and associated webhook options
+
+Here are some general use cases along with the webhook options:
+
+* Allow users to filter which events types to receive
+  * Set the `events` property to the list of event types to receive
+* Allow users to filter Flow and / or Flow Segment events for a specific Flow
+  * Set the `events` to include the Flow and / or Flow Segment event types as required
+  * Add the Flow ID to the `flow_ids` property
+* Allow users to filter Flow and / or Flow Segment events for all Flows of a Source
+  * Set the `events` to include the Flow and / or Flow Segment event types as required
+  * Add the Source ID to the `source_ids` property
+* Allow users to filter Flow and / or Flow Segment events for all Flows collected by a Flow Collection
+  * Set the `events` to include the Flow and / or Flow Segment event types as required
+  * Add the Flow Collection ID to the `flow_collected_by_ids` property
+* Allow users to filter Flow and / or Flow Segment events for a Flow Collection as well as all Flows collected by that Flow Collection
+  * Set the `events` to include the Flow and / or Flow Segment event types as required
+  * Add the Flow Collection ID to the `flow_ids` property
+  * Add the Flow Collection ID to the `flow_collected_by_ids` property
+* Allow users to filter Source events for a Source
+  * Set the `events` to include the Source event types as required
+  * Add the Source ID to the `source_ids` property
+* Allow users to filter Source events for all Sources collected by a Source Collection
+  * Set the `events` to include the Source event types as required
+  * Add the Source ID to the `source_collected_by_ids` property
+* Allow users to filter Source events for all Sources for a Source Collection as well as all Sources collected by that Source Collection
+  * Set the `events` to include the Source event types as required
+  * Add the Source Collection ID to the `source_ids` property
+  * Add the Source ID to the `source_collected_by_ids` property
+* Allow users to filter Flow and / or Flow Segment events for all Flows that have the Source collected by a Source Collection
+  * Set the `events` to include the Flow and / or Flow Segment event types as required
+  * Add the Source Collection ID to the `source_collected_by_ids` property
+* Allow users to filter events for multiple Flows
+  * Set the `events` to include Flow and / or Flow Segment event types as required
+  * Add the Flow IDs to the `flow_ids` property
+* Allow users to filter events for multiple Flow Collections
+  * Set the `events` to include Flow and / or Flow Segment event types as required
+  * Add the Flow Collection IDs to the `flow_collected_by_ids` property
+* Allow users to filter events for multiple Sources
+  * Set the `events` to include the event types as required
+  * Add the Source IDs to the `source_ids` property
+* Allow users to filter events for multiple Source Collections
+  * Set the `events` to include the event types as required
+  * Add the Source Collection IDs to the `source_collected_by_ids` property

--- a/docs/adr/0026-updated-webhook-events-and-filters.md
+++ b/docs/adr/0026-updated-webhook-events-and-filters.md
@@ -36,6 +36,9 @@ Chosen option: Option 4, because that provides what users have explicitly reques
 The assumption is that the extra queries to get the Flow and Source Collection IDs is worth the benefits of having more advanced event filtering on collections.
 Similarly, the event transformation capability to select which `get_urls` to include allows access to content to be limited for certain webhook event recipients that don't have the required permissions.
 
+API implementations may choose to only partially support the filtering and transformation capabilities, but they must return a 400 HTTP error code response on registration if the requested webhook capabilities are not fully supported.
+The avoids the scenario where for example webhook events include presigned URLs even though the API user has set `accept_get_urls` to an empty list because the webhook event recipient does not have permission to access the content.
+
 ### Implementation
 
 Specification changes have been implemented in PR [#105](https://github.com/bbc/tams/pull/105).

--- a/docs/adr/0026-updated-webhook-events-and-filters.md
+++ b/docs/adr/0026-updated-webhook-events-and-filters.md
@@ -1,5 +1,5 @@
 ---
-status: "proposed"
+status: "accepted"
 ---
 # Updated Webhook Events and Filters
 


### PR DESCRIPTION
# Details
This PR makes the following changes to the webhook specified in TAMS:
* The `flows/segments_added` event now includes the list of Flow Segment data structures (`segments`) rather than just a `timerange`.
* Flow and Flow Segment events can be filtered by Source ID (`source_ids` webhook option now also applies to Flows / Flow Segments).
* Flow and Flow Segment events can be filtered by Flow Collections that Flows are `collected_by` (`flow_collected_by_ids` webhook option).
* Flow, Flow Segment and Source events can be filtered by Source Collections that the (Flow's) Source are `collected_by` (`source_collected_by_ids` webhook option).

This PR does not provide a means to transform the events based on options in the webhook registration. For example, being able to disable inclusion of presigned `get_urls` in Flow Segments. However, if the motivation was to not burden the TAMS service with creating presigned URLs then it needs to be disabled for all webhooks rather than be a per-webhook option.

# Jira Issue (if relevant)
Jira URL: https://jira.dev.bbc.co.uk/browse/CLOUDFIT-3547 and https://jira.dev.bbc.co.uk/browse/CLOUDFIT-5377

# Related PRs
_Where appropriate. Indicate order to be merged._

# Submitter PR Checks
_(tick as appropriate)_

- [ ] PR completes task/fixes bug
- [ ] API version has been incremented if necessary
- [ ] ADR status has been updated, and ADR implementation has been recorded
- [ ] Documentation updated (README, etc.)
- [ ] PR added to Jira Issue (if relevant)
- [ ] Follow-up stories added to Jira

# Reviewer PR Checks
_(tick as appropriate)_

- [ ] PR completes task/fixes bug
- [ ] Design makes sense, and fits with our current code base
- [ ] Code is easy to follow
- [ ] PR size is sensible
- [ ] Commit history is sensible and tidy

# Info on PRs
The checks above are guidelines. They don't all have to be ticked, but they should all have been considered.
