### PR TITLE
examples/outgest_file: Fix segment timerange check

### DIFF
--- a/examples/outgest_file.py
+++ b/examples/outgest_file.py
@@ -47,7 +47,7 @@ async def get_flow_segments(
                 segments = await resp.json()
                 for segment in segments:
                     segment_timerange = TimeRange.from_str(segment["timerange"])
-                    if segment_timerange not in timerange:
+                    if segment_timerange.overlaps_with_timerange(timerange):
                         yield segment
                     else:
                         logger.warning(


### PR DESCRIPTION
# Details
The `segment_timerange` needs to overlap with the `--timerange` option (which defaults to TimeRange.eternity()`.

# Jira Issue (if relevant)
Jira URL:

# Related PRs
_Where appropriate. Indicate order to be merged._

# Submitter PR Checks
_(tick as appropriate)_

- [ ] PR completes task/fixes bug
- [ ] API version has been incremented if necessary
- [ ] ADR status has been updated, and ADR implementation has been recorded
- [ ] Documentation updated (README, etc.)
- [ ] PR added to Jira Issue (if relevant)
- [ ] Follow-up stories added to Jira

# Reviewer PR Checks
_(tick as appropriate)_

- [ ] PR completes task/fixes bug
- [ ] Design makes sense, and fits with our current code base
- [ ] Code is easy to follow
- [ ] PR size is sensible
- [ ] Commit history is sensible and tidy

# Info on PRs
The checks above are guidelines. They don't all have to be ticked, but they should all have been considered.
