### PR TITLE
Proposal for an objects endpoint

### DIFF
--- a/api/TimeAddressableMediaStore.yaml
+++ b/api/TimeAddressableMediaStore.yaml
@@ -1859,19 +1859,16 @@ paths:
           description: Forbidden. You do not have permission to modify this flow. It may be marked read-only.
         "404":
           description: The requested flow does not exist.
-  /objects:
+  /objects/{objectId}:
     head:
       summary: Media Object Information
-      description: |
-        Return flow references and other information about media objects.
-
-        The media object ID is provided by the 'object_id' parameter rather than a path component because the object ID string format is unrestricted.
+      description: Return flow references and other information about media objects.
       operationId: HEAD_objects
       tags:
         - Objects
       parameters:
-        - name: object_id
-          in: query
+        - name: objectId
+          in: path
           description: The media object identifier.
           required: true
           schema:
@@ -1907,8 +1904,6 @@ paths:
       description: |
         Contains flows that references the media object and other information.
 
-        The media object ID is provided by the 'object_id' parameter rather than a path component because the object ID string format is unrestricted.
-
         The paging query parameters and headers are required for the list of flow references in the media object.
         API implementations should return a complete list of flow references within reason and API clients should expect
         paging to happen in some rare cases where a media object is used in many flows.
@@ -1916,8 +1911,8 @@ paths:
       tags:
         - Objects
       parameters:
-        - name: object_id
-          in: query
+        - name: objectId
+          in: path
           description: The media object identifier.
           required: true
           schema:
@@ -1947,7 +1942,7 @@ paths:
               schema:
                 $ref: "schemas/object.json"
         "400":
-          description: Bad request. Invalid query options or missing 'object_id'.
+          description: Bad request. Invalid query options.
         "404":
           description: The requested media object does not exist.
   /flow-delete-requests:

--- a/api/TimeAddressableMediaStore.yaml
+++ b/api/TimeAddressableMediaStore.yaml
@@ -1862,7 +1862,10 @@ paths:
   /objects:
     head:
       summary: Media Object Information
-      description: Return flow references and other information about media objects.
+      description: |
+        Return flow references and other information about media objects.
+
+        The media object ID is provided by the 'object_id' parameter rather than a path component because the object ID string format is unrestricted.
       operationId: HEAD_objects
       tags:
         - Objects
@@ -1903,6 +1906,8 @@ paths:
       summary: Media Object Information
       description: |
         Contains flows that references the media object and other information.
+
+        The media object ID is provided by the 'object_id' parameter rather than a path component because the object ID string format is unrestricted.
 
         The paging query parameters and headers are required for the list of flow references in the media object.
         API implementations should return a complete list of flow references within reason and API clients should expect

--- a/api/TimeAddressableMediaStore.yaml
+++ b/api/TimeAddressableMediaStore.yaml
@@ -1859,6 +1859,92 @@ paths:
           description: Forbidden. You do not have permission to modify this flow. It may be marked read-only.
         "404":
           description: The requested flow does not exist.
+  /objects:
+    head:
+      summary: Media Object Information
+      description: Return flow references and other information about media objects.
+      operationId: HEAD_objects
+      tags:
+        - Objects
+      parameters:
+        - name: object_id
+          in: query
+          description: The media object identifier.
+          required: true
+          schema:
+            type: string
+        - $ref: '#/components/parameters/trait_resource_paged_key'
+        - $ref: '#/components/parameters/trait_paged_limit'
+      responses:
+        "200":
+          description: ""
+          headers:
+            Link:
+              description: Provides references to cursors for paging. Only the 'rel' attribute with value 'next' and a link to the next page is currently supported. If 'next' is not present then it is the last page.
+              schema:
+                type: string
+            X-Paging-Limit:
+              description: Identifies the current limit being used for paging. This may not match the requested value if the requested value was too high for the implementation
+              schema:
+                type: integer
+            X-Paging-NextKey:
+              description: Opaque string that can be supplied to the `page` query parameter to get the next page of results.
+              schema:
+                type: string
+          content:
+            application/json:
+              schema:
+                type: string
+        "400":
+          $ref: '#/components/responses/trait_resource_info_head_400'
+        "404":
+          description: The requested media object does not exist.
+    get:
+      summary: Media Object Information
+      description: |
+        Contains flows that references the media object and other information.
+
+        The paging query parameters and headers are required for the list of flow references in the media object.
+        API implementations should return a complete list of flow references within reason and API clients should expect
+        paging to happen in some rare cases where a media object is used in many flows.
+      operationId: GET_objects
+      tags:
+        - Objects
+      parameters:
+        - name: object_id
+          in: query
+          description: The media object identifier.
+          required: true
+          schema:
+            type: string
+        - $ref: '#/components/parameters/trait_resource_paged_key'
+        - $ref: '#/components/parameters/trait_paged_limit'
+      responses:
+        "200":
+          description: ""
+          headers:
+            Link:
+              description: Provides references to cursors for paging. Only the 'rel' attribute with value 'next' and a link to the next page is currently supported. If 'next' is not present then it is the last page.
+              schema:
+                type: string
+            X-Paging-Limit:
+              description: Identifies the current limit being used for paging. This may not match the requested value if the requested value was too high for the implementation
+              schema:
+                type: integer
+            X-Paging-NextKey:
+              description: Opaque string that can be supplied to the `page` query parameter to get the next page of results.
+              schema:
+                type: string
+          content:
+            application/json:
+              example:
+                $ref: examples/objects-get-200.json
+              schema:
+                $ref: "schemas/object.json"
+        "400":
+          description: Bad request. Invalid query options or missing 'object_id'.
+        "404":
+          description: The requested media object does not exist.
   /flow-delete-requests:
     head:
       summary: List Flow Delete Requests
@@ -2247,6 +2333,8 @@ tags:
   - name: FlowSegments
     description: |
       A timerange segment of a Flow that references a media object in the object store.
+  - name: Objects
+    description: The object in the object store that contains the media essence.
   - name: MediaStorage
     description: The system that stores the media objects referenced by flow segments.
   - name: FlowDeleteRequests

--- a/api/examples/objects-get-200.json
+++ b/api/examples/objects-get-200.json
@@ -1,8 +1,8 @@
 {
   "object_id": "tams-6229dd5a-1781-4f80-859f-1a82ee5fa883.ts",
-  "referenced_by": [
+  "referenced_by_flows": [
     "4f79cfd1-c057-47f4-8e4d-1b126ca7bf34",
     "0fde9c11-da9d-434a-a113-d3b20a2cf251"
   ],
-  "first_referenced_by": "4f79cfd1-c057-47f4-8e4d-1b126ca7bf34"
+  "first_referenced_by_flow": "4f79cfd1-c057-47f4-8e4d-1b126ca7bf34"
 }

--- a/api/examples/objects-get-200.json
+++ b/api/examples/objects-get-200.json
@@ -1,0 +1,8 @@
+{
+  "object_id": "tams-6229dd5a-1781-4f80-859f-1a82ee5fa883.ts",
+  "referenced_by": [
+    "4f79cfd1-c057-47f4-8e4d-1b126ca7bf34",
+    "0fde9c11-da9d-434a-a113-d3b20a2cf251"
+  ],
+  "first_referenced_by": "4f79cfd1-c057-47f4-8e4d-1b126ca7bf34"
+}

--- a/api/schemas/object.json
+++ b/api/schemas/object.json
@@ -4,14 +4,14 @@
     "title": "Object",
     "required": [
         "object_id",
-        "referenced_by"
+        "referenced_by_flows"
     ],
     "properties": {
         "object_id": {
             "description": "The media object identifier.",
             "type": "string"
         },
-        "referenced_by": {
+        "referenced_by_flows": {
             "type": "array",
             "description": "List of Flows that reference this media object via Flow Segments in this store.",
             "items": {
@@ -19,8 +19,8 @@
                 "pattern": "^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$"
             }
         },
-        "first_referenced_by": {
-            "description": "The first Flow that had a Flow Segment reference the media object in this store. This Flow is also present in 'referenced_by' if it is still referenced by the Flow. This property is optional and may in some implementations become unset if the Flow no longer references the media object, e.g. because it was deleted.",
+        "first_referenced_by_flow": {
+            "description": "The first Flow that had a Flow Segment reference the media object in this store. This Flow is also present in 'referenced_by_flows' if it is still referenced by the Flow. This property is optional and may in some implementations become unset if the Flow no longer references the media object, e.g. because it was deleted.",
             "type": "string",
             "pattern": "^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$"
         }

--- a/api/schemas/object.json
+++ b/api/schemas/object.json
@@ -1,0 +1,28 @@
+{
+    "type": "object",
+    "description": "Describes a media object in the store.",
+    "title": "Object",
+    "required": [
+        "object_id",
+        "referenced_by"
+    ],
+    "properties": {
+        "object_id": {
+            "description": "The media object identifier.",
+            "type": "string"
+        },
+        "referenced_by": {
+            "type": "array",
+            "description": "List of Flows that reference this media object via Flow Segments in this store.",
+            "items": {
+                "type": "string",
+                "pattern": "^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$"
+            }
+        },
+        "first_referenced_by": {
+            "description": "The first Flow that had a Flow Segment reference the media object in this store. This Flow is also present in 'referenced_by' if it is still referenced by the Flow. This property is optional and may in some implementations become unset if the Flow no longer references the media object, e.g. because it was deleted.",
+            "type": "string",
+            "pattern": "^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$"
+        }
+    }
+}

--- a/docs/adr/0027-add-objects-api-endpoint.md
+++ b/docs/adr/0027-add-objects-api-endpoint.md
@@ -17,7 +17,7 @@ The proposal is to add a `/objects?object_id={object-id}` endpoint that provides
 * Option 2: Add a `/objects?object_id={object-id}` endpoint that lists all Flows that reference a media object
 * Option 3a: Extend 2 to optionally signal which Flow first referenced the media object in the TAMS instance
 * Option 3b: Restrict 3a to require signalling which Flow referenced the media object first
-* Option 3c: Allow a user to set `first_referenced_by`
+* Option 3c: Allow a user to set `first_referenced_by_flow`
 * Option 4: Add an endpoint to list media objects for a Flow
 
 ## Decision Outcome
@@ -42,7 +42,7 @@ The Flows (and Flow Segments) referencing a media object can be found by using a
 ### Option 2: Add a `/objects?object_id={object-id}` endpoint that lists all Flows that reference a media object
 
 This `/objects?object_id={object-id}` endpoint provides JSON that lists of all Flows referencing a media object.
-The `referenced_by` property contains the list of Flow IDs.
+The `referenced_by_flows` property contains the list of Flow IDs.
 
 The Flow Segments that reference the media object can all be found using a GET on `/flows/{flow-id}/segments?object_id={object-id}` for every Flow in the listing rather than every Flow.
 The Flow Segments that reference the media object can all be deleted using a DELETE on `/flows/{flow-id}/segments?object_id={object-id}` for every Flow in the listing.
@@ -68,12 +68,12 @@ This allows Flow-level permissions to be used to restrict which Flow Segments ca
 It may be useful to know which Flow was the first to reference the media object in the TAMS instance.
 This could help determine the origins of the media object.
 
-An optional `first_referenced_by` property is added to the `/objects?object_id={object-id}` resource that contains the Flow ID.
+An optional `first_referenced_by_flow` property is added to the `/objects?object_id={object-id}` resource that contains the Flow ID.
 
-The Flow ID in `first_referenced_by` is set by the TAMS instance and is not settable by a user.
+The Flow ID in `first_referenced_by_flow` is set by the TAMS instance and is not settable by a user.
 
 The TAMS instance should set the property to the first Flow that had a new Flow Segment created that referenced the media object.
-The TAMS instance should also include the Flow ID in the `referenced_by` property if the Flow exists in the TAMS and has a Flow Segment referencing the media object.
+The TAMS instance should also include the Flow ID in the `referenced_by_flows` property if the Flow exists in the TAMS and has a Flow Segment referencing the media object.
 The TAMS instance may either remove or keep the property if the first Flow or the Flow Segments referencing the media object in the first Flow are deleted.
 
 * Good, because it retains some information that could be used to trace the origins of a media object
@@ -82,15 +82,15 @@ The TAMS instance may either remove or keep the property if the first Flow or th
 
 ### Option 3b: Restrict 3a to require signalling which Flow referenced the media object first
 
-This option restricts 3a to require the `first_referenced_by` to be always be set and retain its value.
+This option restricts 3a to require the `first_referenced_by_flow` to be always be set and retain its value.
 
 * Good, because users can rely on the property being set and the value not changing
 * Neutral, because it could reference a Flow that no longer exists
 * Neutral, because it requires a TAMS to record which Flow first referenced a media object
 
-### Option 3c: Allow a user to set `first_referenced_by`
+### Option 3c: Allow a user to set `first_referenced_by_flow`
 
-This options allows a user to set `first_referenced_by` to provide potentially different information about the origins of the media object.
+This options allows a user to set `first_referenced_by_flow` to provide potentially different information about the origins of the media object.
 The Flow ID could be external to the TAMS instance and therefore signal the origin being elsewhere.
 
 * Good, because it could provide information that better informs about the origins of the media object

--- a/docs/adr/0027-add-objects-api-endpoint.md
+++ b/docs/adr/0027-add-objects-api-endpoint.md
@@ -1,0 +1,108 @@
+---
+status: "proposed"
+---
+# Add an objects API endpoint
+
+## Context and Problem Statement
+
+There is a requirement to identify all Flows that reference (via a Flow Segment) a particular media object.
+This for example supports a business or legal requirement to delete a media object from the store, which requires knowing which Flows reference it.
+The media object can be deleted by deleting all (Flow Segment) references to it.
+
+The proposal is to add a `/objects?object_id={object-id}` endpoint that provides a list of Flows that reference (via Flow Segments) the media object.
+
+## Considered Options
+
+* Option 1: Use the existing endpoints to discover which Flows reference a media object
+* Option 2: Add a `/objects?object_id={object-id}` endpoint that lists all Flows that reference a media object
+* Option 3a: Extend 2 to optionally signal which Flow first referenced the media object in the TAMS instance
+* Option 3b: Restrict 3a to require signalling which Flow referenced the media object first
+* Option 3c: Allow a user to set `first_referenced_by`
+* Option 4: Add an endpoint to list media objects for a Flow
+
+## Decision Outcome
+
+Chosen option: Option 3a, because it is a more efficient way to discover which Flows reference a media object and knowing the first reference may help trace the origin of the media object.
+Is there a need to always have the information available and therefore make the property required, i.e. choose option 3b?
+
+### Implementation
+
+The specification changes have been implemented in PR [#111](https://github.com/bbc/tams/pull/111).
+
+## Pros and Cons of the Options
+
+### Option 1: Use the existing endpoints to discover which Flows reference a media object
+
+The Flows (and Flow Segments) referencing a media object can be found by using a GET of `/flows/{flow-id}/segments?object_id={object-id}` for every Flow.
+
+* Good, because there are no changes to the API
+* Bad, because it requires a client to loop through all the Flows to GET the Flow Segments that reference the media object
+* Bad, because it is likely more efficient for TAMS to be asked to run a single query across all Flows then to run multiple queries for each Flow in turn
+
+### Option 2: Add a `/objects?object_id={object-id}` endpoint that lists all Flows that reference a media object
+
+This `/objects?object_id={object-id}` endpoint provides JSON that lists of all Flows referencing a media object.
+The `referenced_by` property contains the list of Flow IDs.
+
+The Flow Segments that reference the media object can all be found using a GET on `/flows/{flow-id}/segments?object_id={object-id}` for every Flow in the listing rather than every Flow.
+The Flow Segments that reference the media object can all be deleted using a DELETE on `/flows/{flow-id}/segments?object_id={object-id}` for every Flow in the listing.
+
+The `object_id` is as a query parameter rather than a URL path component because the media object ID structure is not restricted.
+For example, the `/` character is likely to be used where the object identifiers follow a file-system-like naming structure and it clashes with the use of `/` in the HTTP URL structure.
+
+The `/objects?object_id={object-id}` endpoint does not allow a GET of all media objects; the `object_id` query parameter is required.
+
+The `/objects?object_id={object-id}` endpoint does not allow a POST or PUT to register a media object.
+A media object can only registered in TAMS as part of Flow Segment registration.
+
+The `/objects?object_id={object-id}` endpoint does not allow a DELETE of a media object.
+A media object is only deleted in TAMS after all Flow Segments referencing the media object have been deleted.
+This allows Flow-level permissions to be used to restrict which Flow Segments can be deleted and ultimately whether the media object can be deleted.
+
+* Good, because it is a more efficient way to discover which Flows reference a media object
+* Good, because it supports Flow-level access permissions
+* Neutral, because it requires further requests to discover which Flow Segments reference the media object
+
+### Option 3a: Extend 2 to optionally signal which Flow first referenced the media object in the TAMS instance
+
+It may be useful to know which Flow was the first to reference the media object in the TAMS instance.
+This could help determine the origins of the media object.
+
+An optional `first_referenced_by` property is added to the `/objects?object_id={object-id}` resource that contains the Flow ID.
+
+The Flow ID in `first_referenced_by` is set by the TAMS instance and is not settable by a user.
+
+The TAMS instance should set the property to the first Flow that had a new Flow Segment created that referenced the media object.
+The TAMS instance should also include the Flow ID in the `referenced_by` property if the Flow exists in the TAMS and has a Flow Segment referencing the media object.
+The TAMS instance may either remove or keep the property if the first Flow or the Flow Segments referencing the media object in the first Flow are deleted.
+
+* Good, because it retains some information that could be used to trace the origins of a media object
+* Neutral, because it allows a TAMS instance to decide whether to always keep the property set or not set the property at all
+* Bad, because a user can't set the value and it only reports the origins according to the TAMS instance
+
+### Option 3b: Restrict 3a to require signalling which Flow referenced the media object first
+
+This option restricts 3a to require the `first_referenced_by` to be always be set and retain its value.
+
+* Good, because users can rely on the property being set and the value not changing
+* Neutral, because it could reference a Flow that no longer exists
+* Neutral, because it requires a TAMS to record which Flow first referenced a media object
+
+### Option 3c: Allow a user to set `first_referenced_by`
+
+This options allows a user to set `first_referenced_by` to provide potentially different information about the origins of the media object.
+The Flow ID could be external to the TAMS instance and therefore signal the origin being elsewhere.
+
+* Good, because it could provide information that better informs about the origins of the media object
+* Bad, because it loses the information about which Flow in the TAMS instance was the first to reference the media object.
+Should a different property be provided for users to set?
+
+### Option 4: Add an endpoint to list media objects for a Flow
+
+The `/flows/{flow-id}/segments` endpoint may not provide an efficient way to get a listing of media objects if there are a lot less media objects than Flow Segments.
+This option would add a `/flows/{flow-id}/objects` endpoint for listing media objects for a Flow.
+This would require an index to hold a unique set of media objects for a Flow to avoid duplicates in a paged listing.
+
+* Good, because it allows getting a list of media objects for a Flow
+* Neutral, because it is unclear whether there are practical examples of large reuse of media objects in single Flow
+* Bad, because there is no clear requirement to list media objects rather than Flow Segments

--- a/docs/adr/0027-add-objects-api-endpoint.md
+++ b/docs/adr/0027-add-objects-api-endpoint.md
@@ -9,12 +9,12 @@ There is a requirement to identify all Flows that reference (via a Flow Segment)
 This for example supports a business or legal requirement to delete a media object from the store, which requires knowing which Flows reference it.
 The media object can be deleted by deleting all (Flow Segment) references to it.
 
-The proposal is to add a `/objects?object_id={object-id}` endpoint that provides a list of Flows that reference (via Flow Segments) the media object.
+The proposal is to add a `/objects/{object-id}` endpoint that provides a list of Flows that reference (via Flow Segments) the media object.
 
 ## Considered Options
 
 * Option 1: Use the existing endpoints to discover which Flows reference a media object
-* Option 2: Add a `/objects?object_id={object-id}` endpoint that lists all Flows that reference a media object
+* Option 2: Add a `/objects/{object-id}` endpoint that lists all Flows that reference a media object
 * Option 3a: Extend 2 to optionally signal which Flow first referenced the media object in the TAMS instance
 * Option 3b: Restrict 3a to require signalling which Flow referenced the media object first
 * Option 3c: Allow a user to set `first_referenced_by_flow`
@@ -39,23 +39,22 @@ The Flows (and Flow Segments) referencing a media object can be found by using a
 * Bad, because it requires a client to loop through all the Flows to GET the Flow Segments that reference the media object
 * Bad, because it is likely more efficient for TAMS to be asked to run a single query across all Flows then to run multiple queries for each Flow in turn
 
-### Option 2: Add a `/objects?object_id={object-id}` endpoint that lists all Flows that reference a media object
+### Option 2: Add a `/objects/{object-id}` endpoint that lists all Flows that reference a media object
 
-This `/objects?object_id={object-id}` endpoint provides JSON that lists of all Flows referencing a media object.
+This `/objects/{object-id}` endpoint provides JSON that lists of all Flows referencing a media object.
 The `referenced_by_flows` property contains the list of Flow IDs.
 
 The Flow Segments that reference the media object can all be found using a GET on `/flows/{flow-id}/segments?object_id={object-id}` for every Flow in the listing rather than every Flow.
 The Flow Segments that reference the media object can all be deleted using a DELETE on `/flows/{flow-id}/segments?object_id={object-id}` for every Flow in the listing.
 
-The `object_id` is as a query parameter rather than a URL path component because the media object ID structure is not restricted.
-For example, the `/` character is likely to be used where the object identifiers follow a file-system-like naming structure and it clashes with the use of `/` in the HTTP URL structure.
+The `/objects/{object-id}` URL may have percent encoding if the media object ID contains reserved characters for example.
 
-The `/objects?object_id={object-id}` endpoint does not allow a GET of all media objects; the `object_id` query parameter is required.
+The `/objects` endpoint does not allow a GET of all media objects; the `object_id` path component is required.
 
-The `/objects?object_id={object-id}` endpoint does not allow a POST or PUT to register a media object.
+The `/objects/{object-id}` endpoint does not allow a POST or PUT to register a media object.
 A media object can only registered in TAMS as part of Flow Segment registration.
 
-The `/objects?object_id={object-id}` endpoint does not allow a DELETE of a media object.
+The `/objects/{object-id}` endpoint does not allow a DELETE of a media object.
 A media object is only deleted in TAMS after all Flow Segments referencing the media object have been deleted.
 This allows Flow-level permissions to be used to restrict which Flow Segments can be deleted and ultimately whether the media object can be deleted.
 
@@ -68,7 +67,7 @@ This allows Flow-level permissions to be used to restrict which Flow Segments ca
 It may be useful to know which Flow was the first to reference the media object in the TAMS instance.
 This could help determine the origins of the media object.
 
-An optional `first_referenced_by_flow` property is added to the `/objects?object_id={object-id}` resource that contains the Flow ID.
+An optional `first_referenced_by_flow` property is added to the `/objects/{object-id}` resource that contains the Flow ID.
 
 The Flow ID in `first_referenced_by_flow` is set by the TAMS instance and is not settable by a user.
 


### PR DESCRIPTION
This PR proposes an objects endpoint that includes a list of Flows that references the target media object.

The proposal also adds a property that holds the ID of the Flow that first referenced (via a Flow Segment) the media object. The proposal contains some questions around making the property required rather than optional (as currently specified) and whether a user should be able to set it.

# Jira Issue (if relevant)
Jira URL: https://jira.dev.bbc.co.uk/browse/CLOUDFIT-3550

# Related PRs
_Where appropriate. Indicate order to be merged._

# Submitter PR Checks
_(tick as appropriate)_

- [ ] PR completes task/fixes bug
- [ ] API version has been incremented if necessary
- [ ] ADR status has been updated, and ADR implementation has been recorded
- [ ] Documentation updated (README, etc.)
- [ ] PR added to Jira Issue (if relevant)
- [ ] Follow-up stories added to Jira

# Reviewer PR Checks
_(tick as appropriate)_

- [ ] PR completes task/fixes bug
- [ ] Design makes sense, and fits with our current code base
- [ ] Code is easy to follow
- [ ] PR size is sensible
- [ ] Commit history is sensible and tidy

# Info on PRs
The checks above are guidelines. They don't all have to be ticked, but they should all have been considered.
