### PR TITLE
Restrict timestamp and timerange patterns

### DIFF
--- a/api/schemas/timerange.json
+++ b/api/schemas/timerange.json
@@ -2,5 +2,5 @@
     "title": "TimeRange",
     "description": "A timerange of timestamps. It is represented using one or two timestamps with inclusivity and exclusivity markers.\n\nE.g.\n* `[0:0_10:0)` represents 10 seconds of media starting at timestamp `0:0` and ending before `10:0`.\n* `(5:0_` represents a timerange starting after `5:0` and to eternity.\n* `[1694429247:0_1694429248:0)` is a 1 second TAI timerange starting at 2023-09-11T10:46:50.0Z UTC.\n* `[1694429247:0]` is an instantaneous TAI timerange at 2023-09-11T10:46:50.0Z UTC.\n  This is equivalent to `[1694429247:0_1694429247:0]`.\n  The short syntax is preferred due to ease of identification as instantaneous.\n  Instantaneous TimeRanges cannot use exclusive markers (i.e. `(` or `)`).\n* A `[` or `]` indicates that bound is inclusive, and a `(` or `)` indicates that bound is exclusive.\n\nDetails of the format can be found in the [Timestamps in TAMS](https://github.com/bbc/tams/blob/main/docs/appnotes/0008-timestamps-in-TAMS.md) application note.\n",
     "type": "string",
-    "pattern": "^(\\[|\\()?(-?\\d+:\\d+)?(_(-?\\d+:\\d+)?)?(\\]|\\))?$"
+    "pattern": "^(\\[|\\()?(-?(0|[1-9][0-9]*):(0|[1-9][0-9]{0,8}))?(_(-?(0|[1-9][0-9]*):(0|[1-9][0-9]{0,8}))?)?(\\]|\\))?$"
  }

--- a/api/schemas/timestamp.json
+++ b/api/schemas/timestamp.json
@@ -2,5 +2,5 @@
     "title": "Timestamp",
     "description": "A signed nanosecond resolution timestamp represented as \"{sign?}{seconds}:{nanoseconds}\". The intended\ninterpretation of the value is assumed to be defined elsewhere.\n\nE.g.\n* \"1:40000000\" is the timestamp of the 27th video frame for 25 Hz video with origin at \"0:0\".\n* \"1694429247:40000000\" is the TAI timestamp for a video frame at 2023-09-11T10:46:50.04Z UTC.\n\nDetails of the format can be found in the [Timestamps in TAMS](https://github.com/bbc/tams/blob/main/docs/appnotes/0008-timestamps-in-TAMS.md) application note.\n",
     "type": "string",
-    "pattern": "^-?\\d+:\\d+$"
+    "pattern": "^-?(0|[1-9][0-9]*):(0|[1-9][0-9]{0,8})$"
  }

--- a/docs/appnotes/0008-timestamps-in-TAMS.md
+++ b/docs/appnotes/0008-timestamps-in-TAMS.md
@@ -107,6 +107,8 @@ Of course, if tracking phase difference and/or jitter are important for your use
 
 A Timestamp is represented in the TAMS API using a string with this structure: `{sign?}{seconds}:{nanoseconds}`.
 An optional sign followed by the number of seconds, colon and the number of nanoseconds.
+The `{seconds}` and `{nanoseconds}` must not have any leading zeros.
+The maximum `{nanoseconds}` value is 999999999 (1000^3 - 1).
 
 TAMS Implementations may choose to store Timestamps using different representations.
 For example:


### PR DESCRIPTION
# Details
Limit the nanoseconds value to 999999999 (1000^3-1) and don't allow leading zeros in seconds or nanoseconds.

# Jira Issue (if relevant)
Jira URL: https://jira.dev.bbc.co.uk/browse/CLOUDFIT-5405

# Related PRs
_Where appropriate. Indicate order to be merged._

# Submitter PR Checks
_(tick as appropriate)_

- [ ] PR completes task/fixes bug
- [ ] API version has been incremented if necessary
- [ ] ADR status has been updated, and ADR implementation has been recorded
- [ ] Documentation updated (README, etc.)
- [ ] PR added to Jira Issue (if relevant)
- [ ] Follow-up stories added to Jira

# Reviewer PR Checks
_(tick as appropriate)_

- [ ] PR completes task/fixes bug
- [ ] Design makes sense, and fits with our current code base
- [ ] Code is easy to follow
- [ ] PR size is sensible
- [ ] Commit history is sensible and tidy

# Info on PRs
The checks above are guidelines. They don't all have to be ticked, but they should all have been considered.
