### PR TITLE
danjhd/hls-tags

### DIFF
--- a/docs/appnotes/0003-tag-names.md
+++ b/docs/appnotes/0003-tag-names.md
@@ -181,15 +181,9 @@ However, listing all segments may result in the generation of the HLS manifest t
 
 ### hls_segment_length
 
-Status: **Experimental**
+Status: **Deprecated**
 
-Used in the TAMS demonstration at IBC 2024.
-
-The type is a `number`.
-It is used to calculate the [MEDIA-SEQUENCE](https://datatracker.ietf.org/doc/html/rfc8216#section-4.3.3.2) value in the HLS manifest.
-This tag is only used if the [flow_status](#flow_status) tag value is `ingesting`.
-The value of this tag should be set to the duration of each segment in the flow (in seconds).
-Flows using this feature must therefore have segments of consistant length.
+Replaced by the `segment_duration` field in Flow metadata.
 
 ## Known Source Tags
 

--- a/docs/appnotes/0003-tag-names.md
+++ b/docs/appnotes/0003-tag-names.md
@@ -185,6 +185,24 @@ Status: **Deprecated**
 
 Replaced by the `segment_duration` field in Flow metadata.
 
+### hls_exclude
+
+Status: **Experimental**
+
+Used in the TAMS demonstration at NAB 2025.
+
+The type is a `boolean`.
+It is used to indictate the flow should be excluded from HLS manifest generation.
+Defaults to `false` if the tag is not set.
+
 ## Known Source Tags
 
-There are currently no known Source Tags.
+### hls_exclude
+
+Status: **Experimental**
+
+Used in the TAMS demonstration at NAB 2025.
+
+The type is a `boolean`.
+It is used to indictate the source should be excluded from HLS manifest generation.
+Defaults to `false` if the tag is not set.


### PR DESCRIPTION
# Details
Marks the `hls_segment_length` tag as deprecated in favour of `segment_duration` metadata field.
Proposes new experimental tag that will be used for NAB 2025 `hls_exclude`. This tag is to be used to allow downstream systems to know to ignore flows/sources in HLS manifest generation. One possible scenario for this would be a very high quality content that makes no sense to stream via HLS.

# Jira Issue (if relevant)
Jira URL: n/a

# Related PRs
n/a

# Submitter PR Checks
_(tick as appropriate)_

- [ ] PR completes task/fixes bug
- [ ] API version has been incremented if necessary
- [ ] ADR status has been updated, and ADR implementation has been recorded
- [x] Documentation updated (README, etc.)
- [ ] PR added to Jira Issue (if relevant)
- [ ] Follow-up stories added to Jira

# Reviewer PR Checks
_(tick as appropriate)_

- [ ] PR completes task/fixes bug
- [x] Design makes sense, and fits with our current code base
- [x] Code is easy to follow
- [x] PR size is sensible
- [x] Commit history is sensible and tidy

# Info on PRs
The checks above are guidelines. They don't all have to be ticked, but they should all have been considered.
