### PR TITLE
Only run CI job on fork PRs

### DIFF
--- a/.github/workflows/ci-workflow.yml
+++ b/.github/workflows/ci-workflow.yml
@@ -39,6 +39,7 @@ jobs:
   configure_build:
     name: Configure Build
     runs-on: ubuntu-22.04
+    if: github.event_name == 'pull_request' && ! github.event.pull_request.head.repo.fork
     outputs:
       branches_list: ${{ steps.generate-matrix.outputs.branches_list }}
       shouldUpload: ${{ steps.shouldUpload.outputs.upload }}


### PR DESCRIPTION
# Details
Only run CI job on fork PRs. The `build` and `DeployPages` jobs need `configure_build` and will be skipped if it is. This will avoid the issues with fork PRs seen in https://github.com/bbc/tams/pull/116 and https://github.com/bbc/tams/pull/117 . Note, this pattern has been tested on dummy repos.

# Jira Issue (if relevant)
Jira URL: https://jira.dev.bbc.co.uk/browse/CLOUDFIT-5411

# Related PRs
_Where appropriate. Indicate order to be merged._

# Submitter PR Checks
_(tick as appropriate)_

- [ ] PR completes task/fixes bug
- [ ] API version has been incremented if necessary
- [ ] ADR status has been updated, and ADR implementation has been recorded
- [ ] Documentation updated (README, etc.)
- [ ] PR added to Jira Issue (if relevant)
- [ ] Follow-up stories added to Jira

# Reviewer PR Checks
_(tick as appropriate)_

- [ ] PR completes task/fixes bug
- [ ] Design makes sense, and fits with our current code base
- [ ] Code is easy to follow
- [ ] PR size is sensible
- [ ] Commit history is sensible and tidy

# Info on PRs
The checks above are guidelines. They don't all have to be ticked, but they should all have been considered.
