### PR TITLE
Allow TAMS to support Flow / storage external media objects

### DIFF
--- a/api/TimeAddressableMediaStore.yaml
+++ b/api/TimeAddressableMediaStore.yaml
@@ -1695,13 +1695,16 @@ paths:
         The segment may use a newly-written object, or re-use an existing object from another flow.
 
         For newly-written objects, the client is responsible for ensuring that the segment written to the store obeys the following restrictions:
-        - The object id provided for a segment MUST be one which was received in a POST from /storage for this flow.
         - All samples in the object SHOULD be used by the segment.
         - The timestamps of each sample in the media object MUST equal its position on the Flow timeline, OR `ts_offset` MUST
           be set such that `media_object_ts + ts_offset = segment_ts`
         - The timerange of the segment MUST NOT overlap any other segment in the same Flow. The behaviour is
           undefined if there is an overlap with existing segments and a store may return a 400 error response.
         - The `sample_offset` SHOULD be zero.
+
+        A TAMS MAY support object ids that were not received in a POST from /storage for this flow. In that case the TAMS would need
+        know how to provide access to the media objects for clients and the process for deleting them if necessary.
+        If a TAMS does not support an object id that was not provided by /storage then it SHOULD return a 400 error response.
 
         If a client needs to modify a Flow segment, e.g. to correct metadata such as the `key_frame_count` or add additional
         URLs to `get_urls`, then the client SHOULD first delete the existing segment and then write a new one. The behaviour is

--- a/api/TimeAddressableMediaStore.yaml
+++ b/api/TimeAddressableMediaStore.yaml
@@ -1702,9 +1702,12 @@ paths:
           undefined if there is an overlap with existing segments and a store may return a 400 error response.
         - The `sample_offset` SHOULD be zero.
 
-        A TAMS MAY support object ids that were not received in a POST from /storage for this flow. In that case the TAMS would need
-        know how to provide access to the media objects for clients and the process for deleting them if necessary.
-        If a TAMS does not support an object id that was not provided by /storage then it SHOULD return a 400 error response.
+        A TAMS SHOULD reject registrations of Flow Segments with a 400 error response if it references a newly created media object
+        in the local TAMS storage that was not intended to be used for the Flow. A TAMS SHOULD accept Flow Segments that reference an
+        existing media object in the local TAMS storage that was originally created for another Flow.
+
+        A TAMS MAY support media objects that are held in external storage in another TAMS or other media storage system. The Flow Segment
+        may in that case require the `get_urls` property to provide the information needed by clients to access the media object.
 
         If a client needs to modify a Flow segment, e.g. to correct metadata such as the `key_frame_count` or add additional
         URLs to `get_urls`, then the client SHOULD first delete the existing segment and then write a new one. The behaviour is

--- a/docs/README.md
+++ b/docs/README.md
@@ -37,6 +37,7 @@ For more information on how we use ADRs, see [here](./adr/README.md).
 | [0025](./adr/0025-flow-property-updates.md)                        | Options for updating Flow properties                                       |
 | [0026](./adr/0026-updated-webhook-events-and-filters.md)           | Updates to the webhook event structures and filters                        |
 | [0029](./adr/0029-bulk-flow-segments.md)                           | Changes to flow segments to add segments in bulk                           |
+| [0030](./adr/0030-allow-external-media-objects.md)                 | Allow a Flow to reference media objects in other Flows and storage         |
 
 \* Note: ADR 0004a was the unintended result of a number clash in the early development of TAMS which wasn't caught before publication
 

--- a/docs/adr/0030-allow-external-media-objects.md
+++ b/docs/adr/0030-allow-external-media-objects.md
@@ -51,16 +51,14 @@ The media objects could be held in other storage locations.
 The requirement is loosened so that clients don't need to copy the media objects across to the storage provided by the TAMS instance.
 It also avoids having multiple copies of the same media objects which can complicate management of those media objects.
 
-The TAMS would need to know the location of a media object and how to provide access to those locations to clients.
-This knowledge would allow the TAMS to provide the right Flow Segment `get_urls` for clients to access the media object.
-One possibility is that the media object ID includes a component that tells the TAMS where the media objects is stored.
+The TAMS would need to have information about the media object to provide access to clients.
+This information could be provided in the Flow Segment's `get_urls` by the client that registers the Flow Segment.
+Another possibility is that the media object ID includes a component that informs the TAMS where the media objects is stored and how to access it.
 E.g. the media object ID could be a URI that provides a location component that is populated for external media objects.
-Another possibility is that a TAMS could initiate a copy of the media object if the external location is deemed to not provide the necessary access performance.
 
 Recommendations for handling external media objects and federation are expected to be made in future ADRs and Appnotes.
 These recommendations would extend the [Referencing TAMS content in other systems](../appnotes/0014-referencing-tams-content-in-other-systems.md) Appnote that focusses on Flow and Source level references.
 The [Source-level Edit](../adr/0024-source-level-edit.md) ADR proposes exploration for more direct by-reference operations and this may also include support for referencing external media objects.
 
 * Good, because it allows references to media objects in other locations
-* Neutral, because TAMS implementations would need information to know what to provide in the Flow Segment `get-urls` for clients to access the media objects
-* Neutral, because TAMS implementations would need know how to handle when no more references are made to the media object, e.g. inform the external storage that the media object is no longer referenced and can be deleted
+* Neutral, because TAMS implementations may to need know by some means how to handle when no more references are made to the media object, e.g. inform the external storage that the media object is no longer referenced by the target TAMS and can be deleted

--- a/docs/adr/0030-allow-external-media-objects.md
+++ b/docs/adr/0030-allow-external-media-objects.md
@@ -12,7 +12,7 @@ This requirement also forces copy transfers and duplication of media objects whi
 ## Considered Options
 
 * Option 1: Keep the current media object storage requirements
-* Option 2: Loosen the requirement to allow references to media objects from other Flows
+* Option 2: Loosen the requirement to allow references to existing media objects from other Flows
 * Option 3: Loosen the requirement to allow references to external media objects
 
 ## Decision Outcome
@@ -32,13 +32,17 @@ See the API specification changes in PR [#118](https://github.com/bbc/tams/pull/
 * Bad, because it contradicts the object reuse requirement and expectation that references to media objects in other Flows is supported
 * Bad, because it prevents any form of federation of storage and requires copy transfers to be made
 
-### Option 2: Loosen the requirement to allow references to media objects from other Flows
+### Option 2: Loosen the requirement to allow references to existing media objects from other Flows
 
 Media object reuse is expected to allow reuse across Flows.
 This change is essentially a fix of the specification rather than a feature or breaking change.
 
+This option still requires that a *new* media object is only stored in a location provided by the Flow referencing the media object's `/flows/{flow-id}/storage` endpoint.
+This essentially means that the *new* media object can't be stored in a location that was not intended for the Flow.
+This could be another Flow's intended location or a random location that a client has decided to use.
+
 * Good, because it allows media object reuse as designed
-* Neutral, because TAMS implementations would no longer need to enforce the limitation which requires knowing whether a object storage location was provided by the Flow's `/flows/{flow-id}/storage` endpoint
+* Neutral, because TAMS implementations would no longer need to enforce which location was used if the Flow Segment references an existing media object
 * Neutral, because clients can no longer rely on all TAMS instances to enforce a single Flow media object access control
 
 ### Option 3: Loosen the requirement to allow references to external media objects


### PR DESCRIPTION
# Details
This PR adds a ADR that proposes that a TAMS may support access to media objects in other Flows and media objects in other storage locations. The first follows from the existing expectation for media object reuse and the second for expected requirements for some form of storage federation.

# Jira Issue (if relevant)
Jira URL: https://jira.dev.bbc.co.uk/browse/CLOUDFIT-5407

# Related PRs
_Where appropriate. Indicate order to be merged._

# Submitter PR Checks
_(tick as appropriate)_

- [ ] PR completes task/fixes bug
- [ ] API version has been incremented if necessary
- [ ] ADR status has been updated, and ADR implementation has been recorded
- [ ] Documentation updated (README, etc.)
- [ ] PR added to Jira Issue (if relevant)
- [ ] Follow-up stories added to Jira

# Reviewer PR Checks
_(tick as appropriate)_

- [ ] PR completes task/fixes bug
- [ ] Design makes sense, and fits with our current code base
- [ ] Code is easy to follow
- [ ] PR size is sensible
- [ ] Commit history is sensible and tidy

# Info on PRs
The checks above are guidelines. They don't all have to be ticked, but they should all have been considered.
