### PR TITLE
Specifying storage location when requesting storage allocation

### DIFF
--- a/api/TimeAddressableMediaStore.yaml
+++ b/api/TimeAddressableMediaStore.yaml
@@ -1564,6 +1564,7 @@ paths:
             Flow segment `get_urls` with no label or storage ID cannot be filtered for; they will only be returned if `accept_get_urls` is omitted, and `accept_storage_ids` is omitted or empty.
             Without `get_urls`, the response from the service could be substantially faster if it is not required to
             generate a large number of pre-signed URLs for example.
+            Where multiple filter query parameters are provided, the returned `get_urls` will match all filters.
           schema:
             type: string
             pattern: ^([^,]+(,[^,]+)*)?$
@@ -1575,6 +1576,7 @@ paths:
             An empty `accept_get_urls` results in an empty or no `get_urls` in the response.
             Flow segment `get_urls` with no label or storage ID cannot be filtered for; they will only be returned if `accept_get_urls` is omitted, and `accept_storage_ids` is omitted or empty.
             A full list of available `storage_id`s may be found at the `service/storage_backends` endpoint.
+            Where multiple filter query parameters are provided, the returned `get_urls` will match all filters.
           schema:
             type: string
             pattern: ^([0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12})(,[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12})*$
@@ -1586,6 +1588,7 @@ paths:
             If omitted, both presigned and non-presigned URLs will be returned.
             If `presigned` is set to `false`, the response from the service could be substantially faster if it is not required to
             generate a large number of pre-signed URLs.
+            Where multiple filter query parameters are provided, the returned `get_urls` will match all filters.
           schema:
             type: boolean
         - $ref: '#/components/parameters/trait_resource_paged_key'
@@ -1695,6 +1698,7 @@ paths:
             Flow segment `get_urls` with no label or storage ID cannot be filtered for; they will only be returned if `accept_get_urls` is omitted, and `accept_storage_ids` is omitted or empty.
             Without `get_urls`, the response from the service could be substantially faster if it is not required to
             generate a large number of pre-signed URLs for example.
+            Where multiple filter query parameters are provided, the returned `get_urls` will match all filters.
           schema:
             type: string
             pattern: ^([^,]+(,[^,]+)*)?$
@@ -1706,6 +1710,7 @@ paths:
             An empty `accept_get_urls` results in an empty or no `get_urls` in the response.
             Flow segment `get_urls` with no label or storage ID cannot be filtered for; they will only be returned if `accept_get_urls` is omitted, and `accept_storage_ids` is omitted or empty.
             A full list of available `storage_id`s may be found at the `service/storage_backends` endpoint.
+            Where multiple filter query parameters are provided, the returned `get_urls` will match all filters.
           schema:
             type: string
             pattern: ^([0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12})(,[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12})*$
@@ -1717,6 +1722,7 @@ paths:
             If omitted, both presigned and non-presigned URLs will be returned.
             If `presigned` is set to `false`, the response from the service could be substantially faster if it is not required to
             generate a large number of pre-signed URLs.
+            Where multiple filter query parameters are provided, the returned `get_urls` will match all filters.
           schema:
             type: boolean
         - $ref: '#/components/parameters/trait_resource_paged_key'

--- a/api/TimeAddressableMediaStore.yaml
+++ b/api/TimeAddressableMediaStore.yaml
@@ -89,7 +89,7 @@ paths:
           $ref: '#/components/responses/trait_resource_listing_head_200'
     get:
       summary: Service Information
-      description: Provide information about the service, including the media store in use.
+      description: Provide information about the service.
       operationId: GET_service
       tags:
         - Service
@@ -121,6 +121,31 @@ paths:
           description: Success. The service info has been updated.
         "400":
           description: Bad request. Invalid service JSON.
+  /service/storage_backends:
+    head:
+      summary: Storage Backend Information
+      description: Return storage backends path headers
+      operationId: HEAD_storage_backends
+      tags:
+        - Service
+      responses:
+        "200":
+          $ref: '#/components/responses/trait_resource_listing_head_200'
+    get:
+      summary: Storage Backend Information
+      description: Provide information about the storage backends available on this service instance. These are populated on deployment of the service instance.
+      operationId: GET_storage_backends
+      tags:
+        - Service
+      responses:
+        "200":
+          description: ""
+          content:
+            application/json:
+              schema:
+                $ref: schemas/storage-backends-list.json
+              example:
+                $ref: examples/storage-backends-get-200.json
   /service/webhooks:
     head:
       summary: List Webhook URLs
@@ -1522,18 +1547,47 @@ paths:
           schema:
             default: false
             type: boolean
+        - name: verbose_storage
+          in: query
+          description: |
+            Include storage metadata in `get_urls`.
+            When `verbose_storage` is `false` only `url`, `presigned`, and `label` will be included in `get_urls`.
+          schema:
+            default: false
+            type: boolean
         - name: accept_get_urls
           in: query
           description: |
             A comma separated list of labels of flow segment `get_urls` to include in the response.
-            Omitting `accept_get_urls` will result in all `get_urls` returned.
+            Omitting `accept_get_urls` will result in no filtering of `get_urls`.
             An empty `accept_get_urls` results in an empty or no `get_urls` in the response.
-            Flow segment `get_urls` with no label cannot be filtered for; they will only be returned if `accept_get_urls` is omitted.
+            Flow segment `get_urls` with no label or storage ID cannot be filtered for; they will only be returned if `accept_get_urls` is omitted, and `accept_storage_ids` is omitted or empty.
             Without `get_urls`, the response from the service could be substantially faster if it is not required to
             generate a large number of pre-signed URLs for example.
           schema:
             type: string
             pattern: ^([^,]+(,[^,]+)*)?$
+        - name: accept_storage_ids
+          in: query
+          description: |
+            A comma separated list of `storage_id`s of flow segment `get_urls` to include in the response.
+            Omitting `accept_storage_ids`, or providing an empty `accept_storage_ids` will result in no filtering of `get_urls`.
+            An empty `accept_get_urls` results in an empty or no `get_urls` in the response.
+            Flow segment `get_urls` with no label or storage ID cannot be filtered for; they will only be returned if `accept_get_urls` is omitted, and `accept_storage_ids` is omitted or empty.
+            A full list of available `storage_id`s may be found at the `service/storage_backends` endpoint.
+          schema:
+            type: string
+            pattern: ^([0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12})(,[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12})*$
+        - name: presigned
+          in: query
+          description: |
+            If set to `true`, only presigned URLs (i.e. those whos `presigned` property is `true`) will be returned in `get_urls`.
+            If set to `false`, only non-presigned URLs (i.e. those whos `presigned` property is `false`) will be returned in `get_urls`.
+            If omitted, both presigned and non-presigned URLs will be returned.
+            If `presigned` is set to `false`, the response from the service could be substantially faster if it is not required to
+            generate a large number of pre-signed URLs.
+          schema:
+            type: boolean
         - $ref: '#/components/parameters/trait_resource_paged_key'
         - $ref: '#/components/parameters/trait_paged_limit'
       responses:
@@ -1624,18 +1678,47 @@ paths:
           schema:
             default: false
             type: boolean
+        - name: verbose_storage
+          in: query
+          description: |
+            Include storage metadata in `get_urls`.
+            When `verbose_storage` is `false` only `url`, `presigned`, and `label` will be included in `get_urls`.
+          schema:
+            default: false
+            type: boolean
         - name: accept_get_urls
           in: query
           description: |
             A comma separated list of labels of flow segment `get_urls` to include in the response.
-            Omitting `accept_get_urls` will result in all `get_urls` returned.
+            Omitting `accept_get_urls` will result in no filtering of `get_urls`.
             An empty `accept_get_urls` results in an empty or no `get_urls` in the response.
-            Flow segment `get_urls` with no label cannot be filtered for; they will only be returned if `accept_get_urls` is omitted.
+            Flow segment `get_urls` with no label or storage ID cannot be filtered for; they will only be returned if `accept_get_urls` is omitted, and `accept_storage_ids` is omitted or empty.
             Without `get_urls`, the response from the service could be substantially faster if it is not required to
             generate a large number of pre-signed URLs for example.
           schema:
             type: string
             pattern: ^([^,]+(,[^,]+)*)?$
+        - name: accept_storage_ids
+          in: query
+          description: |
+            A comma separated list of `storage_id`s of flow segment `get_urls` to include in the response.
+            Omitting `accept_storage_ids`, or providing an empty `accept_storage_ids` will result in no filtering of `get_urls`.
+            An empty `accept_get_urls` results in an empty or no `get_urls` in the response.
+            Flow segment `get_urls` with no label or storage ID cannot be filtered for; they will only be returned if `accept_get_urls` is omitted, and `accept_storage_ids` is omitted or empty.
+            A full list of available `storage_id`s may be found at the `service/storage_backends` endpoint.
+          schema:
+            type: string
+            pattern: ^([0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12})(,[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12})*$
+        - name: presigned
+          in: query
+          description: |
+            If set to `true`, only presigned URLs (i.e. those whos `presigned` property is `true`) will be returned in `get_urls`.
+            If set to `false`, only non-presigned URLs (i.e. those whos `presigned` property is `false`) will be returned in `get_urls`.
+            If omitted, both presigned and non-presigned URLs will be returned.
+            If `presigned` is set to `false`, the response from the service could be substantially faster if it is not required to
+            generate a large number of pre-signed URLs.
+          schema:
+            type: boolean
         - $ref: '#/components/parameters/trait_resource_paged_key'
         - $ref: '#/components/parameters/trait_paged_limit'
       responses:
@@ -1748,10 +1831,10 @@ paths:
               $ref: examples/flow-segment-post.json
             schema:
               oneOf:
-              - $ref: schemas/flow-segment.json
+              - $ref: schemas/flow-segment-post.json
               - type: array
                 items:
-                  $ref: schemas/flow-segment.json
+                  $ref: schemas/flow-segment-post.json
         required: true
       responses:
         "200":

--- a/api/TimeAddressableMediaStore.yaml
+++ b/api/TimeAddressableMediaStore.yaml
@@ -1573,7 +1573,6 @@ paths:
           description: |
             A comma separated list of `storage_id`s of flow segment `get_urls` to include in the response.
             Omitting `accept_storage_ids`, or providing an empty `accept_storage_ids` will result in no filtering of `get_urls`.
-            An empty `accept_get_urls` results in an empty or no `get_urls` in the response.
             Flow segment `get_urls` with no label or storage ID cannot be filtered for; they will only be returned if `accept_get_urls` is omitted, and `accept_storage_ids` is omitted or empty.
             A full list of available `storage_id`s may be found at the `service/storage_backends` endpoint.
             Where multiple filter query parameters are provided, the returned `get_urls` will match all filters.
@@ -1635,7 +1634,7 @@ paths:
         Returns the flow segments.
 
         The flow segment provides information about the media object. The media store type, which is
-        indicated in the /service resource, determines the information that is included to allow the
+        indicated in the /service/storage_backends resource, determines the information that is included to allow the
         flow segment's media object to be downloaded. The examples provided here are for the
         "http_object_store" media store type which MUST include a `get_urls` property that contains the
         HTTP URLs for downloading the media object - server implementations should generate this internally.
@@ -1707,7 +1706,6 @@ paths:
           description: |
             A comma separated list of `storage_id`s of flow segment `get_urls` to include in the response.
             Omitting `accept_storage_ids`, or providing an empty `accept_storage_ids` will result in no filtering of `get_urls`.
-            An empty `accept_get_urls` results in an empty or no `get_urls` in the response.
             Flow segment `get_urls` with no label or storage ID cannot be filtered for; they will only be returned if `accept_get_urls` is omitted, and `accept_storage_ids` is omitted or empty.
             A full list of available `storage_id`s may be found at the `service/storage_backends` endpoint.
             Where multiple filter query parameters are provided, the returned `get_urls` will match all filters.

--- a/api/TimeAddressableMediaStore.yaml
+++ b/api/TimeAddressableMediaStore.yaml
@@ -121,11 +121,11 @@ paths:
           description: Success. The service info has been updated.
         "400":
           description: Bad request. Invalid service JSON.
-  /service/storage_backends:
+  /service/storage-backends:
     head:
       summary: Storage Backend Information
       description: Return storage backends path headers
-      operationId: HEAD_storage_backends
+      operationId: HEAD_storage-backends
       tags:
         - Service
       responses:
@@ -134,7 +134,7 @@ paths:
     get:
       summary: Storage Backend Information
       description: Provide information about the storage backends available on this service instance. These are populated on deployment of the service instance.
-      operationId: GET_storage_backends
+      operationId: GET_storage-backends
       tags:
         - Service
       responses:
@@ -1574,7 +1574,7 @@ paths:
             A comma separated list of `storage_id`s of flow segment `get_urls` to include in the response.
             Omitting `accept_storage_ids`, or providing an empty `accept_storage_ids` will result in no filtering of `get_urls`.
             Flow segment `get_urls` with no label or storage ID cannot be filtered for; they will only be returned if `accept_get_urls` is omitted, and `accept_storage_ids` is omitted or empty.
-            A full list of available `storage_id`s may be found at the `service/storage_backends` endpoint.
+            A full list of available `storage_id`s may be found at the `service/storage-backends` endpoint.
             Where multiple filter query parameters are provided, the returned `get_urls` will match all filters.
           schema:
             type: string
@@ -1634,7 +1634,7 @@ paths:
         Returns the flow segments.
 
         The flow segment provides information about the media object. The media store type, which is
-        indicated in the /service/storage_backends resource, determines the information that is included to allow the
+        indicated in the /service/storage-backends resource, determines the information that is included to allow the
         flow segment's media object to be downloaded. The examples provided here are for the
         "http_object_store" media store type which MUST include a `get_urls` property that contains the
         HTTP URLs for downloading the media object - server implementations should generate this internally.
@@ -1707,7 +1707,7 @@ paths:
             A comma separated list of `storage_id`s of flow segment `get_urls` to include in the response.
             Omitting `accept_storage_ids`, or providing an empty `accept_storage_ids` will result in no filtering of `get_urls`.
             Flow segment `get_urls` with no label or storage ID cannot be filtered for; they will only be returned if `accept_get_urls` is omitted, and `accept_storage_ids` is omitted or empty.
-            A full list of available `storage_id`s may be found at the `service/storage_backends` endpoint.
+            A full list of available `storage_id`s may be found at the `service/storage-backends` endpoint.
             Where multiple filter query parameters are provided, the returned `get_urls` will match all filters.
           schema:
             type: string

--- a/api/examples/service-get-200.json
+++ b/api/examples/service-get-200.json
@@ -4,9 +4,6 @@
   "type": "urn:x-tams:service.example",
   "api_version": "1.0",
   "service_version": "tams.1.10.0-da88b8b",
-  "media_store": {
-    "type": "http_object_store"
-  },
   "event_stream_mechanisms": [
     {
       "name": "webhooks",

--- a/api/examples/storage-backends-get-200.json
+++ b/api/examples/storage-backends-get-200.json
@@ -1,0 +1,21 @@
+[
+  {
+    "id": "60af2ab4-e8a5-4c65-a09b-d35983680315",
+    "label": "example-store-name",
+    "store_type": "http_object_store",
+    "provider": "example-cloud-provider",
+    "region": "eu-west-1",
+    "availability_zone": "a",
+    "store_product": "example-storage-product",
+    "default_storage": true
+  },
+  {
+    "id": "323367fd-21bb-4f2e-ad38-faf048c4ccfc",
+    "label": "example-alternative-store-name",
+    "store_type": "http_object_store",
+    "provider": "example-cloud-provider",
+    "region": "eu-west-2",
+    "availability_zone": "a",
+    "store_product": "example-storage-product"
+  }
+]

--- a/api/schemas/flow-segment-post.json
+++ b/api/schemas/flow-segment-post.json
@@ -45,7 +45,7 @@
             "type": "string"
           },
           "label": {
-            "description": "Label identifying this URL. If the 'label' is not set then this URL can't be filtered for using the 'accept_get_urls' API query parameter.",
+            "description": "Label identifying this URL. Service implementations should reject any requests using labels that are already associated with Storage Backends. If the 'label' is not set then this URL can't be filtered for using the 'accept_get_urls' API query parameter.",
             "type": "string"
           }
         }

--- a/api/schemas/flow-segment-post.json
+++ b/api/schemas/flow-segment-post.json
@@ -32,40 +32,23 @@
       "type": "integer"
     },
     "get_urls": {
-      "description": "A list of URLs to which a GET request can be made to directly retrieve the contents of the segment. This is required by the `http_object_store` media store type, which is the only one currently described. Clients may choose any URL in the list and treat the content returned as identical, however servers may sort the list such that the preferred URL is first.",
+      "description": "A list of URLs to which a GET request can be made to directly retrieve the contents of the segment. This is required by the `http_object_store` media store type, which is the only one currently described. Clients may choose any URL in the list and treat them as identical, however servers may sort the list such that the preferred URL is first. `get_urls` should only be used to add uncontrolled URLs. URLs for the provided object_id controlled by the service instance will be populated automatically by the service instance.",
       "type": "array",
       "items": {
         "type": "object",
-        "unevaluatedProperties": false,
-        "allOf": [
-          {
-            "$ref": "storage-backend.json"
+        "required": [
+          "url"
+        ],
+        "properties": {
+          "url": {
+            "description": "A URL to which a GET request can be made to directly retrieve the contents of the segment. Clients should include credentials if the provide URL is on the same origin as the API endpoint",
+            "type": "string"
           },
-          {
-            "type": "object",
-            "required": [
-              "url"
-            ],
-            "properties": {
-              "url": {
-                "description": "A URL to which a GET request can be made to directly retrieve the contents of the segment. Clients should include credentials if the provide URL is on the same origin as the API endpoint",
-                "type": "string"
-              },
-              "presigned": {
-                "description": "If `true`, this URL is pre-signed. If this parameter is unset, the URL is NOT pre-signed.",
-                "type": "boolean"
-              },
-              "label": {
-                "description": "Label identifying this URL. If the 'label' is not set then this URL can't be filtered for using the 'accept_get_urls' API query parameter.",
-                "type": "string"
-              },
-              "controlled": {
-                "description": "If `true`, this URL is on a storage backend controlled by this service instance. If `false`, this URL is uncontrolled and does not have it's lifecycle managed by this instance. If this parameter is unset, assume `true`.",
-                "type": "boolean"
-              }
-            }
+          "label": {
+            "description": "Label identifying this URL. If the 'label' is not set then this URL can't be filtered for using the 'accept_get_urls' API query parameter.",
+            "type": "string"
           }
-        ]
+        }
       }
     },
     "key_frame_count": {

--- a/api/schemas/flow-segment.json
+++ b/api/schemas/flow-segment.json
@@ -47,6 +47,11 @@
               "url"
             ],
             "properties": {
+              "storage_id": {
+                  "description": "Storage backend identifier",
+                  "type": "string",
+                  "pattern": "^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$"
+              },
               "url": {
                 "description": "A URL to which a GET request can be made to directly retrieve the contents of the segment. Clients should include credentials if the provide URL is on the same origin as the API endpoint",
                 "type": "string"

--- a/api/schemas/flow-segment.json
+++ b/api/schemas/flow-segment.json
@@ -32,7 +32,7 @@
       "type": "integer"
     },
     "get_urls": {
-      "description": "A list of URLs to which a GET request can be made to directly retrieve the contents of the segment. This is required by the `http_object_store` media store type, which is the only one currently described. Clients may choose any URL in the list and treat the content returned as identical, however servers may sort the list such that the preferred URL is first.",
+      "description": "A list of URLs to which a GET request can be made to directly retrieve the contents of the segment. This is required by the `http_object_store` media store type, which is the only one currently described. Clients may choose any URL in the list and treat the content returned as identical, however servers may sort the list such that the preferred URL is first. Storage backend metadata for controlled URLs should be populated by the TAMS instance based on the storage backend the object copy resides in.",
       "type": "array",
       "items": {
         "type": "object",
@@ -56,7 +56,7 @@
                 "type": "boolean"
               },
               "label": {
-                "description": "Label identifying this URL. If the 'label' is not set then this URL can't be filtered for using the 'accept_get_urls' API query parameter.",
+                "description": "Label identifying this URL. If the URL is controlled by the service instance, this is the Storage Backend's label. If the URL is uncontrolled, this is the label provided when a client registered the URL. If the 'label' is not set then this URL can't be filtered for using the 'accept_get_urls' API query parameter.",
                 "type": "string"
               },
               "controlled": {

--- a/api/schemas/flow-storage-post.json
+++ b/api/schemas/flow-storage-post.json
@@ -13,6 +13,11 @@
             "items": {
                 "type": "string"
             }
+        },
+        "storage_id": {
+            "description": "The storage backend to allocate storage in. A storage backend identifier as advertised at the `/service` endpoint. If not set the default, as advertised at the `/service` endpoint, will be used if available. An invalid storage backend identifier will result in a 400 error.",
+            "type": "string",
+            "pattern": "^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$"
         }
     },
     "not": {

--- a/api/schemas/service.json
+++ b/api/schemas/service.json
@@ -4,8 +4,7 @@
   "title": "Service",
   "required": [
     "type",
-    "api_version",
-    "media_store"
+    "api_version"
   ],
   "properties": {
     "name": {
@@ -28,20 +27,6 @@
     "service_version": {
       "description": "The version of software providing this service. Note: Different implementations and software houses may use different conventions for their version identification. As such, this field is intentionally permissive and intended to be informative only. Implementations should avoid using this field to determine compatibility.",
       "type": "string"
-    },
-    "media_store": {
-      "type": "object",
-      "description": "Provide information about the media store for this service",
-      "required": [
-        "type"
-      ],
-      "properties": {
-        "type": {
-          "description": "The type of the media store. This determines the endpoints for reading and writing media",
-          "type": "string",
-          "enum": ["http_object_store"]
-        }
-      }
     },
     "event_stream_mechanisms": {
       "type": "array",

--- a/api/schemas/storage-backend.json
+++ b/api/schemas/storage-backend.json
@@ -3,11 +3,6 @@
     "description": "Provides technical, and logic metadata about a storage backend",
     "title": "Storage Backend",
     "properties": {
-        "id": {
-            "description": "Storage backend identifier",
-            "type": "string",
-            "pattern": "^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$"
-        },
         "label": {
             "description": "Freeform string label for a storage backend.",
             "type": "string"

--- a/api/schemas/storage-backend.json
+++ b/api/schemas/storage-backend.json
@@ -9,7 +9,7 @@
             "pattern": "^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$"
         },
         "label": {
-            "description": "Freeform string label for a storage backend. Will be included alongside URLs referencing the storage backend in segment `get_urls`.",
+            "description": "Freeform string label for a storage backend.",
             "type": "string"
         },
         "store_type": {

--- a/api/schemas/storage-backend.json
+++ b/api/schemas/storage-backend.json
@@ -3,10 +3,6 @@
     "description": "Provides technical, and logic metadata about a storage backend",
     "title": "Storage Backend",
     "properties": {
-        "label": {
-            "description": "Freeform string label for a storage backend.",
-            "type": "string"
-        },
         "store_type": {
             "description": "The generic store type. Used to identify the required workflow for reading and writing media. Any `store_product` should be compatible, as much is required for basic interoperability between TAMS implementations, with their associated generic `store_type`.",
             "type": "string",

--- a/api/schemas/storage-backend.json
+++ b/api/schemas/storage-backend.json
@@ -9,7 +9,7 @@
             "pattern": "^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$"
         },
         "label": {
-            "description": "Freeform string label for a storage backend. Will be be included alongside URLs referencing the storage backend in segment `get_urls`.",
+            "description": "Freeform string label for a storage backend. Will be included alongside URLs referencing the storage backend in segment `get_urls`.",
             "type": "string"
         },
         "store_type": {

--- a/api/schemas/storage-backend.json
+++ b/api/schemas/storage-backend.json
@@ -1,0 +1,39 @@
+{
+    "type": "object",
+    "description": "Provides technical, and logic metadata about a storage backend",
+    "title": "Storage Backend",
+    "properties": {
+        "id": {
+            "description": "Storage backend identifier",
+            "type": "string",
+            "pattern": "^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$"
+        },
+        "label": {
+            "description": "Freeform string label for a storage backend. Will be be included alongside URLs referencing the storage backend in segment `get_urls`.",
+            "type": "string"
+        },
+        "store_type": {
+            "description": "The generic store type. Used to identify the required workflow for reading and writing media. Any `store_product` should be compatible, as much is required for basic interoperability between TAMS implementations, with their associated generic `store_type`.",
+            "type": "string",
+            "enum": [
+                "http_object_store"
+            ]
+        },
+        "provider": {
+            "description": "The cloud (or other) provider of the storage",
+            "type": "string"
+        },
+        "region": {
+            "description": "The region in the cloud this storage backend resides",
+            "type": "string"
+        },
+        "availability_zone": {
+            "description": "The availability zone in the cloud region this storage backend resides. Note that many cloud providers randomize availability zone identifiers such that they are consistent within a cloud account, but not necessarily between accounts. Caution should be exercised when using this parameter.",
+            "type": "string"
+        },
+        "store_product": {
+            "description": "The storage product name.",
+            "type": "string"
+        }
+    }
+}

--- a/api/schemas/storage-backends-list.json
+++ b/api/schemas/storage-backends-list.json
@@ -22,6 +22,10 @@
               "type": "string",
               "pattern": "^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$"
           },
+          "label": {
+              "description": "Freeform string label for a storage backend.",
+              "type": "string"
+          },
           "default_storage": {
             "description": "If set to `true`, this is the default storage backend. The default storage backend will be used if the client does not specify a storage backend id when requesting the allocation of storage. If this parameter is not set, assume `false`. Instances may either set one storage backend as default, or none - indicating that clients must always specify a storage backend.",
             "type": "boolean"

--- a/api/schemas/storage-backends-list.json
+++ b/api/schemas/storage-backends-list.json
@@ -17,6 +17,11 @@
       {
         "type": "object",
         "properties": {
+          "id": {
+              "description": "Storage backend identifier",
+              "type": "string",
+              "pattern": "^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$"
+          },
           "default_storage": {
             "description": "If set to `true`, this is the default storage backend. The default storage backend will be used if the client does not specify a storage backend id when requesting the allocation of storage. If this parameter is not set, assume `false`. Instances may either set one storage backend as default, or none - indicating that clients must always specify a storage backend.",
             "type": "boolean"

--- a/api/schemas/storage-backends-list.json
+++ b/api/schemas/storage-backends-list.json
@@ -18,7 +18,7 @@
         "type": "object",
         "properties": {
           "default_storage": {
-            "description": "If set to `true`, this is the default storage backend. The default storage backend will be used if the client does not specify a storage backend id when requesting the allocation of storage. If this parameter is not set, assume `false`.",
+            "description": "If set to `true`, this is the default storage backend. The default storage backend will be used if the client does not specify a storage backend id when requesting the allocation of storage. If this parameter is not set, assume `false`. Instances may either set one storage backend as default, or none - indicating that clients must always specify a storage backend.",
             "type": "boolean"
           }
         }

--- a/api/schemas/storage-backends-list.json
+++ b/api/schemas/storage-backends-list.json
@@ -1,0 +1,29 @@
+{
+  "type": "array",
+  "description": "Information about the storage backends available on this service instance.",
+  "items": {
+    "allOf": [
+      {
+        "$ref": "storage-backend.json"
+      },
+      {
+        "required": [
+          "store_type",
+          "provider",
+          "store_product",
+          "id"
+        ]
+      },
+      {
+        "type": "object",
+        "properties": {
+          "default_storage": {
+            "description": "If set to `true`, this is the default storage backend. The default storage backend will be used if the client does not specify a storage backend id when requesting the allocation of storage. If this parameter is not set, assume `false`.",
+            "type": "boolean"
+          }
+        }
+      }
+    ]
+  },
+  "additionalProperties": false
+}

--- a/api/schemas/webhook-post.json
+++ b/api/schemas/webhook-post.json
@@ -59,11 +59,23 @@
             }
         },
         "accept_get_urls": {
-            "description": "List of labels of URLs to include in the `get_urls` property in `flows/segments_added` events. This option is the same as the `accept_get_urls` query parameter for the /flows/{flowId}/segments API endpoint, except that the labels are represented using a JSON array rather than a (comma separated list) string.",
+            "description": "List of labels of URLs to include in the `get_urls` property in `flows/segments_added` events. Where multiple `get_urls` filter query parameters are provided, the included `get_urls` will match all filters. This option is the same as the `accept_get_urls` query parameter for the /flows/{flowId}/segments API endpoint, except that the labels are represented using a JSON array rather than a (comma separated list) string.",
             "type": "array",
             "items": {
                 "type": "string"
             }
+        },
+        "accept_storage_ids": {
+            "description": "List of labels of `storage_id`s to include in the `get_urls` property in `flows/segments_added` events. Where multiple `get_urls` filter query parameters are provided, the included `get_urls` will match all filters. This option is the same as the `accept_storage_ids` query parameter for the /flows/{flowId}/segments API endpoint, except that the IDs are represented using a JSON array rather than a (comma separated list) string.",
+            "type": "array",
+            "items": {
+                "type": "string",
+                "pattern": "^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$"
+            }
+        },
+        "presigned": {
+            "description": "Whether to include presigned/non-presigned URLs in the `get_urls` property in `flows/segments_added` events. Where multiple `get_urls` filter query parameters are provided, the included `get_urls` will match all filters. This option is the same as the `presigned` query parameter for the /flows/{flowId}/segments API endpoint.",
+            "type": "boolean"
         }
     }
 }

--- a/api/schemas/webhook.json
+++ b/api/schemas/webhook.json
@@ -59,11 +59,23 @@
             }
         },
         "accept_get_urls": {
-            "description": "List of labels of URLs to include in the `get_urls` property in `flows/segments_added` events. This option is the same as the `accept_get_urls` query parameter for the /flows/{flowId}/segments API endpoint, except that the labels are represented using a JSON array rather than a (comma separated list) string.",
+            "description": "List of labels of URLs to include in the `get_urls` property in `flows/segments_added` events. Where multiple `get_urls` filter query parameters are provided, the included `get_urls` will match all filters. This option is the same as the `accept_get_urls` query parameter for the /flows/{flowId}/segments API endpoint, except that the labels are represented using a JSON array rather than a (comma separated list) string.",
             "type": "array",
             "items": {
                 "type": "string"
             }
+        },
+        "accept_storage_ids": {
+            "description": "List of labels of `storage_id`s to include in the `get_urls` property in `flows/segments_added` events. Where multiple `get_urls` filter query parameters are provided, the included `get_urls` will match all filters. This option is the same as the `accept_storage_ids` query parameter for the /flows/{flowId}/segments API endpoint, except that the IDs are represented using a JSON array rather than a (comma separated list) string.",
+            "type": "array",
+            "items": {
+                "type": "string",
+                "pattern": "^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$"
+            }
+        },
+        "presigned": {
+            "description": "Whether to include presigned/non-presigned URLs in the `get_urls` property in `flows/segments_added` events. Where multiple `get_urls` filter query parameters are provided, the included `get_urls` will match all filters. This option is the same as the `presigned` query parameter for the /flows/{flowId}/segments API endpoint.",
+            "type": "boolean"
         }
     }
 }

--- a/docs/README.md
+++ b/docs/README.md
@@ -41,6 +41,7 @@ For more information on how we use ADRs, see [here](./adr/README.md).
 | [0029](./adr/0029-bulk-flow-segments.md)                           | Changes to flow segments to add segments in bulk                           |
 | [0030](./adr/0030-allow-external-media-objects.md)                 | Allow a Flow to reference media objects in other Flows and storage         |
 | [0031](./adr/0031-flow-image-support.md)                           | Add new flow type to support still images                                  |
+| [0032](./adr/0032-specifying-storage-backend.md)                   | Specifying storage backend when requesting storage allocation              |
 | [0034](./adr/0034-storage-allow-object_ids.md)                     | Add object_ids option to Flow Storage request                              |
 
 \* Note: ADR 0004a was the unintended result of a number clash in the early development of TAMS which wasn't caught before publication

--- a/docs/README.md
+++ b/docs/README.md
@@ -50,21 +50,21 @@ For more information on how we use ADRs, see [here](./adr/README.md).
 Application notes are informatative documents describing the recommended usage of the API.
 For more information on how we use application notes, see [here](./appnotes/README.md).
 
-| Application Note Number                                              | Title                                                         |
-| -------------------------------------------------------------------- | ------------------------------------------------------------- |
-| [0001](./appnotes/0001-multi-mono-essence-flows-sources.md)          | Practical Application of the TAMS Content Model               |
-| [0002](./appnotes/0002-Timing-in-MPEG-TS.md)                         | Timing in MPEG-TS                                             |
-| [0003](./appnotes/0003-tag-names.md)                                 | Tags, how to use them, and how we manage them                 |
-| [0004](./appnotes/0004-tams-for-data.md)                             | When TAMS is a good fit for non-media data. And when it’s not |
-| [0005](./appnotes/0005-indepentent-segments.md)                      | Media objects should be independently decodable. Here's why   |
-| [0006](./appnotes/0006-containers-and-mappings.md)                   | Containers and Mappings                                       |
-| [0007](./appnotes/0007-populating-source-metadata.md)                | Populating Source Metadata                                    |
-| [0008](./appnotes/0008-timestamps-in-TAMS.md)                        | Timestamps in TAMS                                            |
-| [0009](./appnotes/0009-storage-label-format.md)                      | Storage label format specification                            |
-| [0010](./appnotes/0010-long-running-sources-and-flows.md)            | Long-running Sources and Flows                                |
-| [0011](./appnotes/0011-c2pa.md)                                      | C2PA provenance across related Sources and Flows              |
-| [0012](./appnotes/0012-using-flow-segment-timeranges.md)             | Using Flow Segment timeranges                                 |
-| [0013](./appnotes/0013-setting-flow-bit-rate-properties.md)          | Setting Flow bit rate properties                              |
-| [0014](./appnotes/0014-referencing-tams-content-in-other-systems.md) | Referencing TAMS content in other systems                     |
-| [0015](./appnotes/0015-using-tams-in-opentimelineio.md)              | Using TAMS in OpenTimelineIO                                  |
-| [0017](./appnotes/0017-reuse-of-ids.md)                              | When to re-use IDs in TAMS and compatible systems             |
+| Application Note Number                                              | Title                                                           |
+| -------------------------------------------------------------------- | --------------------------------------------------------------- |
+| [0001](./appnotes/0001-multi-mono-essence-flows-sources.md)          | Practical Application of the TAMS Content Model                 |
+| [0002](./appnotes/0002-Timing-in-MPEG-TS.md)                         | Timing in MPEG-TS                                               |
+| [0003](./appnotes/0003-tag-names.md)                                 | Tags, how to use them, and how we manage them                   |
+| [0004](./appnotes/0004-tams-for-data.md)                             | When TAMS is a good fit for non-media data. And when it’s not   |
+| [0005](./appnotes/0005-indepentent-segments.md)                      | Media objects should be independently decodable. Here's why     |
+| [0006](./appnotes/0006-containers-and-mappings.md)                   | Containers and Mappings                                         |
+| [0007](./appnotes/0007-populating-source-metadata.md)                | Populating Source Metadata                                      |
+| [0008](./appnotes/0008-timestamps-in-TAMS.md)                        | Timestamps in TAMS                                              |
+| [0009](./appnotes/0009-storage-label-format.md)                      | Storage label format specification - **Superseded by ADR-0032** |
+| [0010](./appnotes/0010-long-running-sources-and-flows.md)            | Long-running Sources and Flows                                  |
+| [0011](./appnotes/0011-c2pa.md)                                      | C2PA provenance across related Sources and Flows                |
+| [0012](./appnotes/0012-using-flow-segment-timeranges.md)             | Using Flow Segment timeranges                                   |
+| [0013](./appnotes/0013-setting-flow-bit-rate-properties.md)          | Setting Flow bit rate properties                                |
+| [0014](./appnotes/0014-referencing-tams-content-in-other-systems.md) | Referencing TAMS content in other systems                       |
+| [0015](./appnotes/0015-using-tams-in-opentimelineio.md)              | Using TAMS in OpenTimelineIO                                    |
+| [0017](./appnotes/0017-reuse-of-ids.md)                              | When to re-use IDs in TAMS and compatible systems               |

--- a/docs/adr/0021-storage-label-format.md
+++ b/docs/adr/0021-storage-label-format.md
@@ -1,6 +1,7 @@
 ---
-status: "accepted"
+status: "superseded by ADR-0032"
 ---
+
 # Label Conventions for get_urls
 
 ## Context and Problem Statement

--- a/docs/adr/0032-specifying-storage-backend.md
+++ b/docs/adr/0032-specifying-storage-backend.md
@@ -1,0 +1,236 @@
+---
+status: "proposed"
+---
+# Specifying storage backend when requesting storage allocation
+
+## Context and Problem Statement
+
+The TAMS API supports the referencing of multiple storage backends for Flow Segments in the [`get_urls`](https://bbc.github.io/tams/main/index.html#/operations/GET_flows-flowId-segments#response-body) list.
+Properties of these locations may be signalled in the label as per [Application Note 0009](https://github.com/bbc/tams/blob/main/docs/appnotes/0009-storage-label-format.md).
+The support for multiple locations in `get_urls` was initially created to allow reference to locations outside of a given TAMS deployment (e.g. in another TAMS deployment, or another system entirely).
+The [allocation of storage](https://bbc.github.io/tams/main/index.html#/operations/POST_flows-flowId-storage) by a TAMS instance does not currently make any provisions for multiple storage backends.
+It currently is up to the TAMS implementation how and where to allocate storage.
+
+Some deployments may want to provide multiple storage backends - for security, cost allocation, tiered storage, or other reasons.
+This ADR explores options for how this may be implemented.
+Note that this ADR relates only to how clients may choose where storage will be allocated.
+This ADR is not proposing any changes to how uploaded content is registered against Flow Segments.
+This ADR is not proposing how multiple TAMS instances may peer with each other.
+
+## Decision Drivers
+
+* Add support for multiple storage backends
+  * Enable new methods of cost allocation in deployments
+  * Enable further methods of authorising access to content (e.g. restrict access to specific storage backends)
+  * Enable tiered storage (though movement of content between those tiers would not currently be defined in the spec)
+* Unify references to storage types across the spec
+  * Storage backends are currently referenced in the [AppNote0009](https://github.com/bbc/tams/blob/main/docs/appnotes/0009-storage-label-format.md) label structure, and the `media_store` parameter at the `/service` endpoint in different ways
+  * This ADR would result in the addition of further references when selecting storage backends when allocation storage
+* Fulfil the elevation of the components of the [AppNote0009](https://github.com/bbc/tams/blob/main/docs/appnotes/0009-storage-label-format.md) label structure to the core API as planned in [ADR0021](https://github.com/bbc/tams/blob/main/docs/adr/0021-storage-label-format.md)
+* Avoid further potential breaking changes to references to storage backends if the elevation of the components of the [AppNote0009](https://github.com/bbc/tams/blob/main/docs/appnotes/0009-storage-label-format.md) label structure to the core API happened at a later date
+
+## Considered Options
+
+* Option 1a: Multiple separate TAMS instances using the existing API with no changes
+* Option 1b: Update the TAMS API to allow storage backend to be specified when requestion storage allocation
+* Option 2a: Specify storage backend using the [AppNote0009](https://github.com/bbc/tams/blob/main/docs/appnotes/0009-storage-label-format.md) label structure
+* Option 2b: Specify storage backend using the storeName portion of [AppNote0009](https://github.com/bbc/tams/blob/main/docs/appnotes/0009-storage-label-format.md) label structure
+* Option 2c: Specify storage backend using a storage backend UUID
+* Option 3a: Configure storage backends out-of-band
+* Option 3b: Expand `media_store` parameter at the `/service` endpoint to advertise available storage names/IDs
+* Option 3c: Expand `media_store` parameter at the `/service` endpoint to advertise available storage names/IDs, with storage metadata
+* Option 3d: Replace the `media_store` parameter at the `/service` endpoint with a `/service/storage_backends` endpoint to advertise available storage names/IDs, with storage metadata
+* Option 4a: Don't modify approach to `get_urls` `label`
+* Option 4b: Elevate the components of [AppNote0009](https://github.com/bbc/tams/blob/main/docs/appnotes/0009-storage-label-format.md) label structure to core spec
+* Option 5a: Don't add any additional filters on the flow `/segments`
+* Option 5b: Add a storage backend ID filter to the flow `/segments` endpoint
+* Option 5c: Add a pre-signed filter to the flow `/segments` endpoint
+
+## Decision Outcome
+
+Chosen options:
+
+* Option 1b: Update the TAMS API to allow storage backend to be specified when requestion storage allocation
+* Option 2c: Specify storage backend using a storage backend UUID
+* Option 3d: Replace the `media_store` parameter at the `/service` endpoint with a `/service/storage_backends` endpoint to advertise available storage names/IDs, with storage metadata
+* Option 4b: Elevate the components of [AppNote0009](https://github.com/bbc/tams/blob/main/docs/appnotes/0009-storage-label-format.md) label structure to core spec
+* Option 5b: Add a storage backend ID filter to the flow `/segments` endpoint
+* Option 5c: Add a pre-signed filter to the flow `/segments` endpoint
+
+Supersede [ADR0021](https://github.com/bbc/tams/blob/main/docs/adr/0021-storage-label-format.md)
+Deprecate [AppNote0009](https://github.com/bbc/tams/blob/main/docs/appnotes/0009-storage-label-format.md)
+
+### Consequences
+
+* Good, because references to storage backends will be unified
+* Good, because it enables workflows that require multiple storage backends (e.g. tiered storage)
+* Bad, because it will result in a breaking change
+
+<!-- This is an optional element. Feel free to remove. -->
+### Implementation
+
+{Once the proposal has been implemented, add a link to the relevant PRs here}
+
+## Pros and Cons of the Options
+
+### Option 1a: Multiple separate TAMS instances using the existing API with no changes
+
+Clients are currently able to interact with multiple TAMS instances, as they would with multiple instances of any other API.
+Each instance could be associated with an specific storage type/backend.
+Clients may request the allocation of storage or specific type/backend from the relevant TAMS instance which controls it, and uploaded content to it.
+The client may then register that content against Flow Segments on multiple TAMS instances, if required for discoverability.
+But the lifecycle of those objects registered to a TAMS instance which doesn't control them - in particular deletion and generation of pre-signed URLs where required - would currently have to be handled by the client, or an off-spec extension.
+Alternatively, the instances may peer with each other to share content.
+How peering may work is outside of the scope of this ADR.
+This option also requires the running of duplicate services where they might not otherwise be needed.
+This option may also imped the discovery and re-use of content across TAMS instances.
+
+* Good, because it doesn't require a spec change
+* Neutral, because clients may have to be able to communicate with multiple TAMS instances anyway when crossing business boundaries
+* Bad, because resource use is poor
+* Bad, because it relies on off-spec management of the lifecycle of Objects in some cases
+* Bad, because it requires clients to communicate with multiple TAMS instances for more use cases
+* Bad, because it impedes zero-copy re-use of Segments
+
+### Option 1b: Update the TAMS API to allow storage backend to be specified when requestion storage allocation
+
+Clients would be able to specify their required storage backend when requesting the allocation of storage.
+Clients supporting this feature would manage multiple storage layers for different technical/business purposes such as cost allocation, tiered storage, geographical location etc.
+For consistency, this should take the form of an additional parameter in the request body for `/storage` POST requests.
+
+* Good, because it reduces the content-management burden on clients
+* Good, because it provides clear responsibility for the lifecycle management of Objects
+* Good, because content discoverability and re-use matches current single-instance TAMS use
+* Good, because it reduces the number of use-cases that require clients to communicate with multiple TAMS instances
+* Neutral, because clients may have to be able to communicate with multiple TAMS instances anyway when crossing business boundaries
+* Neutral, because it requires a backwards-compatible spec change
+* Bad, because it adds complexity to TAMS instances which support this feature
+
+### Option 2a: Specify storage backend using the [AppNote0009](https://github.com/bbc/tams/blob/main/docs/appnotes/0009-storage-label-format.md) label structure
+
+[AppNote0009](https://github.com/bbc/tams/blob/main/docs/appnotes/0009-storage-label-format.md) describes a structured string format for describing storage location, type, and name.
+This Application Note used the existing `get_urls` `label` property to test the usefulness of its components without the potential breaking changes of parameters specified in the API itself.
+The intention, as stated in [ADR0021](https://github.com/bbc/tams/blob/main/docs/adr/0021-storage-label-format.md), is that the components of these labels will be elevated to the core spec once they are considered stable.
+This means any use of this label structure for the purpose of specifying storage backends would likely require a breaking change in the part of the spec defining that specification once the elevation of that change happens.
+Additionally, the core spec doesn't currently require the use of AppNote0009 label structures.
+That said, AppNote0009 is currently the only strongly defined method of referring to storage backends.
+
+* Good, because it re-uses an existing structured label format for storage
+* Neutral, because it is very verbose
+* Bad, because it will likely require a future breaking change
+
+### Option 2b: Specify storage backend using the storeName portion of [AppNote0009](https://github.com/bbc/tams/blob/main/docs/appnotes/0009-storage-label-format.md) label structure
+
+A small modification to [AppNote0009](https://github.com/bbc/tams/blob/main/docs/appnotes/0009-storage-label-format.md) would be to require the `storeName` component of the `label` to be unique to a given storage backend.
+This likely matches expected behaviour and current use.
+It would allow for the specification of storage backends using only that component.
+This would also likely mean that the location specification aspect of the API spec wouldn't have to be modified once the `get_urls` `label` components are elevated to the core spec.
+This has the downside that the core spec doesn't currently require the use of AppNote0009 labels.
+
+* Good, because it should avoid a future breaking change
+* Neutral, because it is less verbose than the full [AppNote0009](https://github.com/bbc/tams/blob/main/docs/appnotes/0009-storage-label-format.md) format
+* Bad, because it would currently differ in format to `get_urls` `labels` (This bad point would be negated if we also choose Option 4b)
+
+### Option 2c: Specify storage backend using a storage backend UUID
+
+This option adds a UUID storage backend ID.
+This would be used to specify the storage backend when allocating storage.
+This is consistent with other resources in the API.
+
+* Good, because it would likely avoid a future breaking change in this part of the store
+* Good, because it is consistent with resources in the wider API
+* Good, because it would be less verbose than the full [AppNote0009](https://github.com/bbc/tams/blob/main/docs/appnotes/0009-storage-label-format.md) format, while providing unambiguous references
+* Bad, because it would currently differ in format to `get_urls` `labels`, which currently has a similar purpose
+
+### Option 3a: Configure storage backends out-of-band
+
+Whatever representation is used for specifying the storage backend, a common understanding of storage identifiers and the storage they refer to is required for a TAMS service instance and its clients.
+Users deploying TAMS systems are likely to have significant control of the TAMS service, clients, or both.
+This option assumes that one or both of server/clients may have their store names configured on deployment.
+
+* Good, because it doesn't require a change to the API Spec
+* Neutral, because integration engineers may need to configure these things manually at deployment anyway
+* Bad, because it requires more work by integration engineers for more use cases
+* Bad, because it could result in proprietary solutions
+
+### Option 3b: Expand `media_store` parameter at the `/service` endpoint to advertise available storage names/IDs
+
+This option is to advertise a list of available storage names/IDs that may be used by the client at the `/service` endpoint.
+The `media_store` parameter at this endpoint currently provides a simplistic description of the type of storage the store will allocate.
+This parameter pre-dates [AppNote0009](https://github.com/bbc/tams/blob/main/docs/appnotes/0009-storage-label-format.md) and provides far less information.
+The parameter could be re-purposed and expanded to provide list of storage names available in the simplest case.
+It is worth noting that this endpoint should only advertise storage names that the TAMS instance can allocate and manage.
+It is possible to register `get_urls` to Segments which are external to the TAMS instance.
+This option would not alter that feature.
+This option would, in principle, allow for storage types to be added/removed without re-deploying the service.
+But this ADR does not specify how this should be implemented.
+
+* Good, because it enables a level of automatic configuration of this behaviour between servers and clients - at least in advertising available stores to users
+* Neutral, because this would be a breaking change in a lesser used part of the API
+* Bad, because it provides limited information for choosing the best store - particularly through automated mechanisms
+
+### Option 3c: Expand `media_store` parameter at the `/service` endpoint to advertise available storage names/IDs, with storage metadata
+
+As with Option 3b, but with a dict providing the metadata currently available in [AppNote0009](https://github.com/bbc/tams/blob/main/docs/appnotes/0009-storage-label-format.md) `get_urls` labels.
+
+* Good, because it enables automatic configuration of this behaviour between servers and clients
+* Good, because it provides enough technical metadata to automate the choosing of stores in some cases
+* Neutral, because this would be a breaking change in a lesser used part of the API
+* Bad, because it would currently differ in format to `get_urls` `labels` and would pre-empt what changes the future breaking change to elevate label parameters to the core API would look like (This bad point would be negated if we also choose Option 4b)
+
+### Option 3d: Replace the `media_store` parameter at the `/service` endpoint with a `/service/storage_backends` endpoint to advertise available storage names/IDs, with storage metadata
+
+As with Option 3c, but the `media_store` parameter is removed and replaced with a child endpoint.
+
+* Good, because it enables automatic configuration of this behaviour between servers and clients
+* Good, because it provides enough technical metadata to automate the choosing of stores in some cases
+* Good, because it would allow easier paging of the storage backends
+* Neutral, because this would be a breaking change in a lesser used part of the API
+* Bad, because it would currently differ in format to `get_urls` `labels` and would pre-empt what changes the future breaking change to elevate label parameters to the core API would look like (This bad point would be negated if we also choose Option 4b)
+
+### Option 4a: Don't modify approach to `get_urls` `label`
+
+Currently, the `get_urls` `label` field is a free-text string.
+[AppNote0009](https://github.com/bbc/tams/blob/main/docs/appnotes/0009-storage-label-format.md) recommends a structure which includes useful information such as storage type, provider, and location.
+This option is to maintain the current approach with no changes.
+
+* Good, because it doesn't require an API change
+* Good, because it provides further time to validate the components in [AppNote0009](https://github.com/bbc/tams/blob/main/docs/appnotes/0009-storage-label-format.md) labels
+* Neutral, because it pushes out a breaking change we expect to make in future further
+* Bad, because it would potentially lead to references to storage backends at the `/service` endpoint and when requesting allocation being formatted differently, depending on what other Options are chosen
+
+### Option 4b: Elevate the components of [AppNote0009](https://github.com/bbc/tams/blob/main/docs/appnotes/0009-storage-label-format.md) label structure to core spec
+
+[ADR0021](https://github.com/bbc/tams/blob/main/docs/adr/0021-storage-label-format.md) resulted in the creation of [AppNote0009](https://github.com/bbc/tams/blob/main/docs/appnotes/0009-storage-label-format.md) as a means to convey additional information about storage in the `get_urls` `label` field.
+ADR0021 intended the use of AppNote0009 labels as a temporary solution to validate the useful of the components contained within it, and that a later change would elevate the components to the core spec.
+As mentioned in Option 2a and 2b, the addition of the ability to specify storage backends for allocations crosses over with this capability.
+In adding the ability to specify storage backends we either have to work to AppNote0009 and expect a future breaking change, pre-empt what the superseding solution to ADR0021 would look like, or implement that superseding solution alongside the storage backend specification support.
+This option is to make that superseding solution now alongside the ability to specify storage backends.
+
+* Good, because it will unify the references to storage at the `/service`, `get_urls`, and `/storage` parts of the API
+* Good, because it would better support multiple storage backends (including tiered storage)
+* Bad, because it's a (potentially) breaking change to a core part of the API, though one we have been planning to make for some time
+
+### Option 5a: Don't add any additional filters on the flow `/segments` endpoint
+
+Currently, `get_urls` can be filter by their `label` using the `accept_get_urls` query string.
+This option would keep that as the primary means of filtering `get_urls` on their storage backend.
+
+* Good, because it doesn't require any API changes
+* Bad, because `get_urls` `label` parameters are not required to be unique to a storage backend
+* Bad, because [AppNote0009](https://github.com/bbc/tams/blob/main/docs/appnotes/0009-storage-label-format.md) is only advisory, limiting filtering ability
+
+### Option 5b: Add a storage backend ID filter to the flow `/segments` endpoint
+
+Add a query string filter to the flow `/segments` endpoint that would filter `get_urls` on the storage backend ID.
+
+* Good, because it allows unambiguous filtering of `get_urls` on their storage backend
+* Good, because it allows managed URLs to be filtered for
+* Neutral, because it requires a non-breaking change
+
+### Option 5c: Add a pre-signed filter to the flow `/segments` endpoint
+
+Add a query string filter to the flow `/segments` endpoint that would filter `get_urls` for pre-signed or non-pre-signed URLs.
+
+* Good, because it allows clients to filter for pre-signed URLs using a standardised approach
+* Neutral, because it requires a non-breaking change

--- a/docs/adr/0032-specifying-storage-backend.md
+++ b/docs/adr/0032-specifying-storage-backend.md
@@ -69,10 +69,9 @@ Deprecate [AppNote0009](https://github.com/bbc/tams/blob/main/docs/appnotes/0009
 * Good, because it enables workflows that require multiple storage backends (e.g. tiered storage)
 * Bad, because it will result in a breaking change
 
-<!-- This is an optional element. Feel free to remove. -->
 ### Implementation
 
-{Once the proposal has been implemented, add a link to the relevant PRs here}
+Implemented by [#125](https://github.com/bbc/tams/pull/125).
 
 ## Pros and Cons of the Options
 

--- a/docs/adr/0032-specifying-storage-backend.md
+++ b/docs/adr/0032-specifying-storage-backend.md
@@ -9,7 +9,7 @@ The TAMS API supports the referencing of multiple storage backends for Flow Segm
 Properties of these locations may be signalled in the label as per [Application Note 0009](https://github.com/bbc/tams/blob/main/docs/appnotes/0009-storage-label-format.md).
 The support for multiple locations in `get_urls` was initially created to allow reference to locations outside of a given TAMS deployment (e.g. in another TAMS deployment, or another system entirely).
 The [allocation of storage](https://bbc.github.io/tams/main/index.html#/operations/POST_flows-flowId-storage) by a TAMS instance does not currently make any provisions for multiple storage backends.
-It currently is up to the TAMS implementation how and where to allocate storage.
+It currently is up to the TAMS implementation to decide how and where to allocate storage.
 
 Some deployments may want to provide multiple storage backends - for security, cost allocation, tiered storage, or other reasons.
 This ADR explores options for how this may be implemented.

--- a/docs/adr/0032-specifying-storage-backend.md
+++ b/docs/adr/0032-specifying-storage-backend.md
@@ -1,5 +1,5 @@
 ---
-status: "proposed"
+status: "accepted"
 ---
 # Specifying storage backend when requesting storage allocation
 

--- a/docs/adr/0032-specifying-storage-backend.md
+++ b/docs/adr/0032-specifying-storage-backend.md
@@ -45,6 +45,8 @@ This ADR is not proposing how multiple TAMS instances may peer with each other.
 * Option 5a: Don't add any additional filters on the flow `/segments`
 * Option 5b: Add a storage backend ID filter to the flow `/segments` endpoint
 * Option 5c: Add a pre-signed filter to the flow `/segments` endpoint
+* Option 6a: Assume storage backends will be configured at deploy time
+* Option 6b: Allow storage backends to be added/removed via the API
 
 ## Decision Outcome
 
@@ -56,6 +58,7 @@ Chosen options:
 * Option 4b: Elevate the components of [AppNote0009](https://github.com/bbc/tams/blob/main/docs/appnotes/0009-storage-label-format.md) label structure to core spec
 * Option 5b: Add a storage backend ID filter to the flow `/segments` endpoint
 * Option 5c: Add a pre-signed filter to the flow `/segments` endpoint
+* Option 6a: Assume storage backends will be configured at deploy time
 
 Supersede [ADR0021](https://github.com/bbc/tams/blob/main/docs/adr/0021-storage-label-format.md)
 Deprecate [AppNote0009](https://github.com/bbc/tams/blob/main/docs/appnotes/0009-storage-label-format.md)
@@ -234,3 +237,26 @@ Add a query string filter to the flow `/segments` endpoint that would filter `ge
 
 * Good, because it allows clients to filter for pre-signed URLs using a standardised approach
 * Neutral, because it requires a non-breaking change
+
+### Option 6a: Assume storage backends will be configured at deploy time
+
+It is likely that TAMS deployments will want to add/remove storage backends over time.
+
+This option is to assume that this will happen at deploy time.
+The addition/removal of storage backends will likely require the addition/removal of permissions, credentials, and other infrastructure changes to allow the TAMS service instance control of the storage backend.
+This will likely happen via changes to the infrastructure-as-code that describes the deployment, and performing an update operation on the deployment.
+As such, this option assumes that the configuration that populates the storage backends will be updated via the same process.
+
+* Good, because it reduces the complexity of the API
+* Good, because it promotes best practice of managing service configuration in deployment tooling
+* Good, because service instances can handle storage backend configuration statically
+* Neutral, because it requires a rolling upgrade/service instance replacement to update the available storage backends
+
+### Option 6b: Allow storage backends to be added/removed via the API
+
+This option is to add additional HTTP methods for the adding/removal of storage backends
+
+* Neutral, because it requires additional HTTP methods
+* Neutral, because available storage backends can be updated without a rolling upgrade/service instance replacement
+* Bad, because it splits service configuration between the API and deployment tooling
+* Bad, because it requires dynamic distribution of storage backend configuration between service instances where redundant instances are used

--- a/docs/adr/0032-specifying-storage-backend.md
+++ b/docs/adr/0032-specifying-storage-backend.md
@@ -39,7 +39,7 @@ This ADR is not proposing how multiple TAMS instances may peer with each other.
 * Option 3a: Configure storage backends out-of-band
 * Option 3b: Expand `media_store` parameter at the `/service` endpoint to advertise available storage names/IDs
 * Option 3c: Expand `media_store` parameter at the `/service` endpoint to advertise available storage names/IDs, with storage metadata
-* Option 3d: Replace the `media_store` parameter at the `/service` endpoint with a `/service/storage_backends` endpoint to advertise available storage names/IDs, with storage metadata
+* Option 3d: Replace the `media_store` parameter at the `/service` endpoint with a `/service/storage-backends` endpoint to advertise available storage names/IDs, with storage metadata
 * Option 4a: Don't modify approach to `get_urls` `label`
 * Option 4b: Elevate the components of [AppNote0009](https://github.com/bbc/tams/blob/main/docs/appnotes/0009-storage-label-format.md) label structure to core spec
 * Option 5a: Don't add any additional filters on the flow `/segments`
@@ -54,7 +54,7 @@ Chosen options:
 
 * Option 1b: Update the TAMS API to allow storage backend to be specified when requesting storage allocation
 * Option 2c: Specify storage backend using a storage backend UUID
-* Option 3d: Replace the `media_store` parameter at the `/service` endpoint with a `/service/storage_backends` endpoint to advertise available storage names/IDs, with storage metadata
+* Option 3d: Replace the `media_store` parameter at the `/service` endpoint with a `/service/storage-backends` endpoint to advertise available storage names/IDs, with storage metadata
 * Option 4b: Elevate the components of [AppNote0009](https://github.com/bbc/tams/blob/main/docs/appnotes/0009-storage-label-format.md) label structure to core spec
 * Option 5b: Add a storage backend ID filter to the flow `/segments` endpoint
 * Option 5c: Add a pre-signed filter to the flow `/segments` endpoint
@@ -180,7 +180,7 @@ As with Option 3b, but with a dict providing the metadata currently available in
 * Neutral, because this would be a breaking change in a lesser used part of the API
 * Bad, because it would currently differ in format to `get_urls` `labels` and would pre-empt what changes the future breaking change to elevate label parameters to the core API would look like (This bad point would be negated if we also choose Option 4b)
 
-### Option 3d: Replace the `media_store` parameter at the `/service` endpoint with a `/service/storage_backends` endpoint to advertise available storage names/IDs, with storage metadata
+### Option 3d: Replace the `media_store` parameter at the `/service` endpoint with a `/service/storage-backends` endpoint to advertise available storage names/IDs, with storage metadata
 
 As with Option 3c, but the `media_store` parameter is removed and replaced with a child endpoint.
 

--- a/docs/adr/0032-specifying-storage-backend.md
+++ b/docs/adr/0032-specifying-storage-backend.md
@@ -32,7 +32,7 @@ This ADR is not proposing how multiple TAMS instances may peer with each other.
 ## Considered Options
 
 * Option 1a: Multiple separate TAMS instances using the existing API with no changes
-* Option 1b: Update the TAMS API to allow storage backend to be specified when requestion storage allocation
+* Option 1b: Update the TAMS API to allow storage backend to be specified when requesting storage allocation
 * Option 2a: Specify storage backend using the [AppNote0009](https://github.com/bbc/tams/blob/main/docs/appnotes/0009-storage-label-format.md) label structure
 * Option 2b: Specify storage backend using the storeName portion of [AppNote0009](https://github.com/bbc/tams/blob/main/docs/appnotes/0009-storage-label-format.md) label structure
 * Option 2c: Specify storage backend using a storage backend UUID
@@ -50,7 +50,7 @@ This ADR is not proposing how multiple TAMS instances may peer with each other.
 
 Chosen options:
 
-* Option 1b: Update the TAMS API to allow storage backend to be specified when requestion storage allocation
+* Option 1b: Update the TAMS API to allow storage backend to be specified when requesting storage allocation
 * Option 2c: Specify storage backend using a storage backend UUID
 * Option 3d: Replace the `media_store` parameter at the `/service` endpoint with a `/service/storage_backends` endpoint to advertise available storage names/IDs, with storage metadata
 * Option 4b: Elevate the components of [AppNote0009](https://github.com/bbc/tams/blob/main/docs/appnotes/0009-storage-label-format.md) label structure to core spec
@@ -92,7 +92,7 @@ This option may also imped the discovery and re-use of content across TAMS insta
 * Bad, because it requires clients to communicate with multiple TAMS instances for more use cases
 * Bad, because it impedes zero-copy re-use of Segments
 
-### Option 1b: Update the TAMS API to allow storage backend to be specified when requestion storage allocation
+### Option 1b: Update the TAMS API to allow storage backend to be specified when requesting storage allocation
 
 Clients would be able to specify their required storage backend when requesting the allocation of storage.
 Clients supporting this feature would manage multiple storage layers for different technical/business purposes such as cost allocation, tiered storage, geographical location etc.

--- a/docs/appnotes/0009-storage-label-format.md
+++ b/docs/appnotes/0009-storage-label-format.md
@@ -1,4 +1,7 @@
-# Storage label format specification
+# 0009: Storage label format specification
+
+> [!CAUTION]
+> DEPRECATED: See [ADR0032](https://github.com/bbc/tams/blob/main/docs/appnotes/0032-specifying-storage-backend.md) for more details
 
 ## Abstract
 


### PR DESCRIPTION
# Details
This PR adds the ability to to specify storage locations when requesting storage allocation.
This PR unifies references to storage backends at various points in the API.

# Jira Issue (if relevant)
Jira URL: https://jira.dev.bbc.co.uk/browse/CLOUDFIT-5406

# Related PRs
_Where appropriate. Indicate order to be merged._

# Submitter PR Checks
_(tick as appropriate)_

- [ ] PR completes task/fixes bug
- [ ] API version has been incremented if necessary
- [ ] ADR status has been updated, and ADR implementation has been recorded
- [ ] Documentation updated (README, etc.)
- [ ] PR added to Jira Issue (if relevant)
- [ ] Follow-up stories added to Jira

# Reviewer PR Checks
_(tick as appropriate)_

- [ ] PR completes task/fixes bug
- [ ] Design makes sense, and fits with our current code base
- [ ] Code is easy to follow
- [ ] PR size is sensible
- [ ] Commit history is sensible and tidy

# Info on PRs
The checks above are guidelines. They don't all have to be ticked, but they should all have been considered.
