### PR TITLE
Allow `ts_offset` to be a negative offset

### DIFF
--- a/api/schemas/flow-segment-post.json
+++ b/api/schemas/flow-segment-post.json
@@ -12,7 +12,7 @@
       "type": "string"
     },
     "ts_offset": {
-      "description": "The timestamp offset between the sample timestamps stored in the media file and the corresponding timestamp in the segment, ie. ts_offset = segment ts - media object ts. Assumed to be 0:0 if not set. Format as described by the [Timestamp](../schemas/timestamp#top) type, but cannot be negative",
+      "description": "The timestamp offset between the sample timestamps stored in the media file and the corresponding timestamp in the segment, ie. ts_offset = segment ts - media object ts. Assumed to be 0:0 if not set. Format as described by the [Timestamp](../schemas/timestamp#top) type",
       "$ref": "timestamp.json"
     },
     "timerange": {

--- a/api/schemas/flow-segment.json
+++ b/api/schemas/flow-segment.json
@@ -12,7 +12,7 @@
       "type": "string"
     },
     "ts_offset": {
-      "description": "The timestamp offset between the sample timestamps stored in the media file and the corresponding timestamp in the segment, ie. ts_offset = segment ts - media object ts. Assumed to be 0:0 if not set. Format as described by the [Timestamp](../schemas/timestamp#top) type, but cannot be negative",
+      "description": "The timestamp offset between the sample timestamps stored in the media file and the corresponding timestamp in the segment, ie. ts_offset = segment ts - media object ts. Assumed to be 0:0 if not set. Format as described by the [Timestamp](../schemas/timestamp#top) type",
       "$ref": "timestamp.json"
     },
     "timerange": {


### PR DESCRIPTION
# Details
Relaxes an erroneous restriction that `ts_offset` cannot be negative: the offset maps the media object timeline into the Flow timeline, and there is no particular stipulation as to which way that offset occurs.

~~*Question*: Are we happy this is a fix since it seems obvious it's wrong, or does it deserve a version bump?~~ - see comment below

(thanks to @johnbilt for the report)

# Jira Issue (if relevant)
Jira URL: https://jira.dev.bbc.co.uk/browse/CLOUDFIT-5459

# Related PRs
Introduced by https://github.com/bbc/tams/pull/9

# Submitter PR Checks
_(tick as appropriate)_

- [X] PR completes task/fixes bug
- [ ] API version has been incremented if necessary
- [ ] ADR status has been updated, and ADR implementation has been recorded
- [ ] Documentation updated (README, etc.)
- [ ] PR added to Jira Issue (if relevant)
- [ ] Follow-up stories added to Jira

# Reviewer PR Checks
_(tick as appropriate)_

- [ ] PR completes task/fixes bug
- [ ] Design makes sense, and fits with our current code base
- [ ] Code is easy to follow
- [ ] PR size is sensible
- [ ] Commit history is sensible and tidy

# Info on PRs
The checks above are guidelines. They don't all have to be ticked, but they should all have been considered.
