### PR TITLE
add status and error fields to webhook records

### DIFF
--- a/api/TimeAddressableMediaStore.yaml
+++ b/api/TimeAddressableMediaStore.yaml
@@ -214,7 +214,7 @@ paths:
               schema:
                 type: array
                 items:
-                  $ref: "schemas/webhook-with-id.json"
+                  $ref: "schemas/webhook-get.json"
         "404":
           description: "Webhooks are not supported by this API implementation"
     post:
@@ -250,7 +250,7 @@ paths:
               example:
                 $ref: "examples/webhook-get-200.json"
               schema:
-                $ref: schemas/webhook-with-id.json
+                $ref: schemas/webhook-get.json
         "400":
           description: Bad request. Invalid parameters or unsupported event filtering or transformation.
         "404":
@@ -292,7 +292,7 @@ paths:
               example:
                 $ref: "examples/webhook-get-200.json"
               schema:
-                $ref: "schemas/webhook-with-id.json"
+                $ref: "schemas/webhook-get.json"
         "404":
           description: The requested Webhook ID in the path is invalid, or Webhooks are not supported by this API implementation
     put:
@@ -330,7 +330,7 @@ paths:
               example:
                 $ref: "examples/webhook-get-200.json"
               schema:
-                $ref: schemas/webhook.json
+                $ref: schemas/webhook-get.json
         "400":
           description: Bad request. Invalid parameters or unsupported event filtering or transformation.
         "404":

--- a/api/schemas/webhook-get.json
+++ b/api/schemas/webhook-get.json
@@ -1,0 +1,19 @@
+{
+    "title": "Webhook Detail",
+    "description": "Describes a Webhook",
+    "type": "object",
+    "allOf": [
+        {
+            "$ref": "webhook-with-id.json"
+        },
+        {
+            "type": "object",
+            "properties": {
+                "error": {
+                    "description": "Provides more information for the error status, as described by the [Error](../schemas/error#top) type",
+                    "$ref": "error.json"
+                }
+            }
+        }
+    ]
+}

--- a/api/schemas/webhook.json
+++ b/api/schemas/webhook.json
@@ -86,6 +86,14 @@
         "verbose_storage": {
             "description": "Whether to include storage metadata in the `get_urls` property in `flows/segments_added` events. This option is the same as the `verbose_storage` query parameter for the /flows/{flowId}/segments API endpoint.",
             "type": "boolean"
+        },
+        "status": {
+            "description": "Status of the Webhook. A disabled webhook will not POST events.",
+            "type": "string",
+            "enum": [
+                "enabled",
+                "disabled"
+            ]
         }
     }
 }

--- a/api/schemas/webhook.json
+++ b/api/schemas/webhook.json
@@ -90,6 +90,7 @@
         "status": {
             "description": "Status of the Webhook. A disabled webhook will not POST events.",
             "type": "string",
+            "default": "enabled",
             "enum": [
                 "enabled",
                 "disabled"


### PR DESCRIPTION
# Details
A very simple PR to suggest a way to add status and error to the webhooks schema.

# Jira Issue (if relevant)
Jira URL: n/a

# Related PRs
https://github.com/bbc/tams/pull/142
I am targeting this PR into the branch being used for that PR. Do not merge into any other branch.

# Submitter PR Checks
_(tick as appropriate)_

- [ ] PR completes task/fixes bug
- [ ] API version has been incremented if necessary
- [ ] ADR status has been updated, and ADR implementation has been recorded
- [ ] Documentation updated (README, etc.)
- [ ] PR added to Jira Issue (if relevant)
- [ ] Follow-up stories added to Jira

# Reviewer PR Checks
_(tick as appropriate)_

- [ ] PR completes task/fixes bug
- [ ] Design makes sense, and fits with our current code base
- [ ] Code is easy to follow
- [ ] PR size is sensible
- [ ] Commit history is sensible and tidy

# Info on PRs
The checks above are guidelines. They don't all have to be ticked, but they should all have been considered.
