### PR TITLE
examples/simple_edit: default to 0:0 segment ts_offset as mandated by spec

### DIFF
--- a/examples/simple_edit.py
+++ b/examples/simple_edit.py
@@ -157,7 +157,7 @@ async def simple_edit(
             # The media timeline started at zero when the ingest started, so `ts_offset` indicates what must be
             # added to the media time to get the Flow time.
             # So we can calculate media time at the start of the segment
-            seg_offset = Timestamp.from_str(segment["ts_offset"])
+            seg_offset = Timestamp.from_str(segment.get("ts_offset", "0:0"))
             media_time = seg_tr.start - seg_offset
 
             # Now we want to know what to add to that media time to get the new start time


### PR DESCRIPTION
Provide correct default for ts_offset in simple_edit script.

# Details
The spec for GetFlowSegments states that ts_offset is optional, but the example simple_edit script crashes if ts_offset is not in the response.

Fix by providing the appropriate default.

# Submitter PR Checks
_(tick as appropriate)_

- [x] PR completes task/fixes bug
- [ ] API version has been incremented if necessary
- [ ] ADR status has been updated, and ADR implementation has been recorded
- [ ] Documentation updated (README, etc.)
- [ ] PR added to Jira Issue (if relevant)
- [ ] Follow-up stories added to Jira

# Reviewer PR Checks
_(tick as appropriate)_

- [ ] PR completes task/fixes bug
- [ ] Design makes sense, and fits with our current code base
- [ ] Code is easy to follow
- [ ] PR size is sensible
- [ ] Commit history is sensible and tidy

# Info on PRs
The checks above are guidelines. They don't all have to be ticked, but they should all have been considered.
