### PR TITLE
Remove text about 404 if label not set

### DIFF
--- a/api/TimeAddressableMediaStore.yaml
+++ b/api/TimeAddressableMediaStore.yaml
@@ -747,7 +747,7 @@ paths:
         "200":
           $ref: '#/components/responses/trait_resource_info_head_200'
         "404":
-          description: The requested Source does not exist, or does not have a label set.
+          description: The requested Source does not exist.
     get:
       summary: Source Label
       description: Returns the Source label property. This should be a very short, human-readable label that may be displayed in listings of Sources.
@@ -764,7 +764,7 @@ paths:
               schema:
                 type: string
         "404":
-          description: The requested Source does not exist, or does not have a label set.
+          description: The requested Source does not exist.
     put:
       summary: Create or Update Source Label
       description: Create or update the label property. This should be a very short, human-readable label that may be displayed in listings of Sources.
@@ -1371,7 +1371,7 @@ paths:
         "200":
           $ref: '#/components/responses/trait_resource_info_head_200'
         "404":
-          description: The requested Flow does not exist, or does not have a label set.
+          description: The requested Flow does not exist.
     get:
       summary: Flow Label
       description: Returns the Flow label property. This should be a very short, human-readable label that may be displayed in listings of Flows.
@@ -1388,7 +1388,7 @@ paths:
               schema:
                 type: string
         "404":
-          description: The requested Flow does not exist, or does not have a label set.
+          description: The requested Flow does not exist.
     put:
       summary: Create or Update Flow Label
       description: Create or update the label property. This should be a very short, human-readable label that may be displayed in listings of Flows.


### PR DESCRIPTION
# Details
404 would indicate the resource was not found, but in this case it was found, it just had no value.
Aligns with the other requests (e.g. `GET /flows/{flowID}/description`

I've put this as bugfix, although I can see at least [one implementation](https://github.com/sohonetlabs/rustytams/blob/main/tams-server/src/handlers/flow_props.rs#L74) that implements the behaviour as described, so I'd appreciate a second opinion on whether it's an API break

# Jira Issue (if relevant)
Jira URL: N/A

# Related PRs
N/A

# Submitter PR Checks
_(tick as appropriate)_

- [X] PR completes task/fixes bug
- [X] API version has been incremented if necessary
- [ ] ADR status has been updated, and ADR implementation has been recorded
- [ ] Documentation updated (README, etc.)
- [ ] PR added to Jira Issue (if relevant)
- [ ] Follow-up stories added to Jira

# Reviewer PR Checks
_(tick as appropriate)_

- [ ] PR completes task/fixes bug
- [ ] Design makes sense, and fits with our current code base
- [ ] Code is easy to follow
- [ ] PR size is sensible
- [ ] Commit history is sensible and tidy

# Info on PRs
The checks above are guidelines. They don't all have to be ticked, but they should all have been considered.
