### PR TITLE
Make `role` optional in collections, capture the same information elsewhere

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,7 +95,7 @@ Media workflows and applications are likely to use Sources as their references t
 Then some logic can be applied to identify a suitable Flow representing that Source at the point when operations need to be performed on the media, for example choosing between proxy-quality for an offline edit and full-quality for a render.
 
 The TAMS API stores both Flows and Sources, each of which can be assigned a label, description and some tags alongside relevant technical metadata.
-Flows can be collected into other Flows (with an optional `role` parameter to ascribe meaning to the relationship, and a `priority` to define sort order).
+Flows can be collected into other Flows (with an optional `role` parameter to ascribe meaning to the relationship).
 Sources can collect together other Sources, by inference from the relationships defined by their Flows.
 This implementation is deliberately kept very simple, and lacks efficient mechansisms to query the graph of Sources and Flows.
 More sophisticated mechanisms for recording and querying relationships between model entities is out of scope for this API, but could in principle be provided by a separate complementary service dedicated to that purpose in the future.

--- a/README.md
+++ b/README.md
@@ -95,7 +95,7 @@ Media workflows and applications are likely to use Sources as their references t
 Then some logic can be applied to identify a suitable Flow representing that Source at the point when operations need to be performed on the media, for example choosing between proxy-quality for an offline edit and full-quality for a render.
 
 The TAMS API stores both Flows and Sources, each of which can be assigned a label, description and some tags alongside relevant technical metadata.
-Flows can be collected into other Flows (with a `role` parameter to ascribe meaning to the relationship).
+Flows can be collected into other Flows (with an optional `role` parameter to ascribe meaning to the relationship, and a `priority` to define sort order).
 Sources can collect together other Sources, by inference from the relationships defined by their Flows.
 This implementation is deliberately kept very simple, and lacks efficient mechansisms to query the graph of Sources and Flows.
 More sophisticated mechanisms for recording and querying relationships between model entities is out of scope for this API, but could in principle be provided by a separate complementary service dedicated to that purpose in the future.

--- a/api/TimeAddressableMediaStore.yaml
+++ b/api/TimeAddressableMediaStore.yaml
@@ -923,6 +923,10 @@ paths:
                   summary: Multi-essence Source
                   description: Multi-essence Sources collect multiple Sources of different formats under one Source ID.
                   externalValue: examples/source-get-200-multi.json
+                tags:
+                  summary: Source with tags
+                  description: Source example with tags set matching associated Flow
+                  externalValue: examples/source-get-200-tags.json
         "404":
           description: The requested Source does not exist.
   /sources/{sourceId}/tags:
@@ -1542,6 +1546,9 @@ paths:
                 video_vfr:
                   summary: Video Flow - H.264 Codec, Variable Frame Rate
                   externalValue: examples/flow-get-200-video-h264-vfr.json
+                video_cleanfeed:
+                  summary: Video Flow - H.264 Codec, with Editorial Purpose Tag
+                  externalValue: examples/flow-get-200-video-h264-cleanfeed.json
                 audio:
                   summary: Audio Flow - AAC Codec
                   externalValue: examples/flow-get-200-audio-aac.json

--- a/api/TimeAddressableMediaStore.yaml
+++ b/api/TimeAddressableMediaStore.yaml
@@ -1593,7 +1593,7 @@ paths:
         Service implementations SHOULD verify that Flow metadata is compatible with the associated Source.
         Service implementations MAY accept modification/addition of parameters, and reflect such changes in the Source, where it will not bring any Flows of the Source into conflict.
         Where metadata would result in any Flow of the Source coming into conflict, the request SHOULD be rejected with a 400 response.
-        Examples of conflicting metadata include `format` not matching, or the `priority` or `role` in `source_collection` and `flow_collection` not matching.
+        Examples of conflicting metadata include `format` not matching, or `role` or ordering in `source_collection` and `flow_collection` not matching.
         It may also be possible for service implementations to detect some instances where multiple Flows should not be considered of the same Source, such as audio Flows with different numbers of tracks.
         Further guidance on when Flows/Sources may be considered the same/different may be found in the [Practical Guidance for Media](https://specs.amwa.tv/ms-04/releases/v1.0.0/docs/3.0._Practical_Guidance_for_Media.html) section of AMWA MS-04.
 
@@ -2021,7 +2021,7 @@ paths:
           $ref: '#/components/responses/trait_resource_info_head_404'
     get:
       summary: Flow Collection
-      description: Returns the Flow collection property. A list of Flows that are collected together by this Flow, sorted in ascending `priority` order (where no `priority` sorts last).
+      description: Returns the Flow collection property. An ordered list of Flows that are collected together by this Flow.
       operationId: GET_flows-flowId-flow-collection
       tags:
         - Flows
@@ -2039,7 +2039,7 @@ paths:
     put:
       summary: Create or Update Flow Collection
       description: |
-        Create or update the Flow collection property. A list of Flows that are collected together by this Flow.
+        Create or update the Flow collection property. An ordered list of Flows that are collected together by this Flow.
 
         Service implementations SHOULD verify that Flow metadata is compatible with the associated Source.
         Service implementations MAY accept modification/addition of parameters, and reflect such changes in the Source, where it will not bring any Flows of the Source into conflict.

--- a/api/TimeAddressableMediaStore.yaml
+++ b/api/TimeAddressableMediaStore.yaml
@@ -1593,7 +1593,7 @@ paths:
         Service implementations SHOULD verify that Flow metadata is compatible with the associated Source.
         Service implementations MAY accept modification/addition of parameters, and reflect such changes in the Source, where it will not bring any Flows of the Source into conflict.
         Where metadata would result in any Flow of the Source coming into conflict, the request SHOULD be rejected with a 400 response.
-        Examples of conflicting metadata include `format` not matching, or the `priority` in `source_collection` and `flow_collection` not matching.
+        Examples of conflicting metadata include `format` not matching, or the `priority` or `role` in `source_collection` and `flow_collection` not matching.
         It may also be possible for service implementations to detect some instances where multiple Flows should not be considered of the same Source, such as audio Flows with different numbers of tracks.
         Further guidance on when Flows/Sources may be considered the same/different may be found in the [Practical Guidance for Media](https://specs.amwa.tv/ms-04/releases/v1.0.0/docs/3.0._Practical_Guidance_for_Media.html) section of AMWA MS-04.
 

--- a/api/TimeAddressableMediaStore.yaml
+++ b/api/TimeAddressableMediaStore.yaml
@@ -1586,7 +1586,7 @@ paths:
         Service implementations SHOULD verify that Flow metadata is compatible with the associated Source.
         Service implementations MAY accept modification/addition of parameters, and reflect such changes in the Source, where it will not bring any Flows of the Source into conflict.
         Where metadata would result in any Flow of the Source coming into conflict, the request SHOULD be rejected with a 400 response.
-        Examples of conflicting metadata include `format` not matching, or the `role` in `source_collection` and `flow_collection` not matching.
+        Examples of conflicting metadata include `format` not matching, or the `priority` in `source_collection` and `flow_collection` not matching.
         It may also be possible for service implementations to detect some instances where multiple Flows should not be considered of the same Source, such as audio Flows with different numbers of tracks.
         Further guidance on when Flows/Sources may be considered the same/different may be found in the [Practical Guidance for Media](https://specs.amwa.tv/ms-04/releases/v1.0.0/docs/3.0._Practical_Guidance_for_Media.html) section of AMWA MS-04.
 
@@ -2014,7 +2014,7 @@ paths:
           $ref: '#/components/responses/trait_resource_info_head_404'
     get:
       summary: Flow Collection
-      description: Returns the Flow collection property. A list of Flows that are collected together by this Flow.
+      description: Returns the Flow collection property. A list of Flows that are collected together by this Flow, sorted in ascending `priority` order (where no `priority` sorts last).
       operationId: GET_flows-flowId-flow-collection
       tags:
         - Flows

--- a/api/examples/flow-collection-get-200.json
+++ b/api/examples/flow-collection-get-200.json
@@ -1,14 +1,11 @@
 [
     {
-        "id": "4f79cfd1-c057-47f4-8e4d-1b126ca7bf34",
-        "role": "video"
+        "id": "4f79cfd1-c057-47f4-8e4d-1b126ca7bf34"
     },
     {
-        "id": "6101df05-06bb-41b8-8af4-cf7cd33df209",
-        "role": "audio"
+        "id": "6101df05-06bb-41b8-8af4-cf7cd33df209"
     },
     {
-        "id": "e85efab4-993b-4ad6-9af3-4cd8d0d38860",
-        "role": "subtitles"
+        "id": "e85efab4-993b-4ad6-9af3-4cd8d0d38860"
     }
 ]

--- a/api/examples/flow-collection-put.json
+++ b/api/examples/flow-collection-put.json
@@ -1,14 +1,11 @@
 [
     {
-        "id": "4f79cfd1-c057-47f4-8e4d-1b126ca7bf34",
-        "role": "video"
+        "id": "4f79cfd1-c057-47f4-8e4d-1b126ca7bf34"
     },
     {
-        "id": "6101df05-06bb-41b8-8af4-cf7cd33df209",
-        "role": "audio"
+        "id": "6101df05-06bb-41b8-8af4-cf7cd33df209"
     },
     {
-        "id": "e85efab4-993b-4ad6-9af3-4cd8d0d38860",
-        "role": "subtitles"
+        "id": "e85efab4-993b-4ad6-9af3-4cd8d0d38860"
     }
 ]

--- a/api/examples/flow-get-200-multi-container-map.json
+++ b/api/examples/flow-get-200-multi-container-map.json
@@ -11,11 +11,16 @@
     "flow_collection": [
         {
             "id": "32b75860-83e5-48c9-8d6b-de46bdbc7f80",
-            "role": "video"
+            "priority": 1,
+            "container_mapping": {
+                "mp2ts_container": {
+                    "pid": 256
+                }
+            }
         },
         {
             "id": "94996f2e-0cb5-43d3-ab6c-db5a9cf667aa",
-            "role": "L",
+            "priority": 1,
             "container_mapping": {
                 "track_index": 1,
                 "format_track_index": 0,
@@ -26,7 +31,7 @@
         },
         {
             "id": "9ba0523e-22a0-4c69-a598-baf4be244a79",
-            "role": "R",
+            "priority": 2,
             "container_mapping": {
                 "track_index": 2,
                 "format_track_index": 1,

--- a/api/examples/flow-get-200-multi-container-map.json
+++ b/api/examples/flow-get-200-multi-container-map.json
@@ -11,7 +11,6 @@
     "flow_collection": [
         {
             "id": "32b75860-83e5-48c9-8d6b-de46bdbc7f80",
-            "priority": 1,
             "container_mapping": {
                 "mp2ts_container": {
                     "pid": 256
@@ -20,7 +19,6 @@
         },
         {
             "id": "94996f2e-0cb5-43d3-ab6c-db5a9cf667aa",
-            "priority": 1,
             "container_mapping": {
                 "track_index": 1,
                 "format_track_index": 0,
@@ -31,7 +29,6 @@
         },
         {
             "id": "9ba0523e-22a0-4c69-a598-baf4be244a79",
-            "priority": 2,
             "container_mapping": {
                 "track_index": 2,
                 "format_track_index": 1,

--- a/api/examples/flow-get-200-multi.json
+++ b/api/examples/flow-get-200-multi.json
@@ -1,6 +1,8 @@
 {
     "id": "e85efab4-993b-4ad6-9af3-4cd8d0d38860",
     "source_id": "a77d0061-0878-4e8a-a114-772d03f952c1",
+    "description": "SRT Feed 1",
+    "label": "OB Truck A Mix Out",
     "format": "urn:x-nmos:format:multi",
     "generation": 0,
     "created": "2023-12-14T16:34:58.131620",
@@ -10,11 +12,16 @@
     "flow_collection": [
         {
             "id": "4f79cfd1-c057-47f4-8e4d-1b126ca7bf34",
-            "role": "video"
+            "priority": 1
         },
         {
             "id": "6101df05-06bb-41b8-8af4-cf7cd33df209",
-            "role": "audio"
+            "priority": 1
+        },
+        {
+            "id": "c8943cb3-08df-46de-8ce8-0d7d70ed204c",
+            "role": "audio_description",
+            "priority": 2
         },
         {
             "id": "e85efab4-993b-4ad6-9af3-4cd8d0d38860",

--- a/api/examples/flow-get-200-multi.json
+++ b/api/examples/flow-get-200-multi.json
@@ -11,17 +11,14 @@
     },
     "flow_collection": [
         {
-            "id": "4f79cfd1-c057-47f4-8e4d-1b126ca7bf34",
-            "priority": 1
+            "id": "4f79cfd1-c057-47f4-8e4d-1b126ca7bf34"
         },
         {
-            "id": "6101df05-06bb-41b8-8af4-cf7cd33df209",
-            "priority": 1
+            "id": "6101df05-06bb-41b8-8af4-cf7cd33df209"
         },
         {
             "id": "c8943cb3-08df-46de-8ce8-0d7d70ed204c",
-            "role": "audio_description",
-            "priority": 2
+            "role": "audio_description"
         },
         {
             "id": "e85efab4-993b-4ad6-9af3-4cd8d0d38860",

--- a/api/examples/flow-get-200-video-h264-cleanfeed.json
+++ b/api/examples/flow-get-200-video-h264-cleanfeed.json
@@ -1,0 +1,49 @@
+{
+    "id": "18e7f92e-4cbf-40e2-beb6-e9f6e2fb5af3",
+    "source_id": "a0456629-b25d-4c4b-b631-0861621f67c7",
+    "generation": 0,
+    "created": "2008-05-27T18:53:00Z",
+    "metadata_updated": "2023-09-14T09:45:26Z",
+    "segments_updated": "2023-09-14T09:45:26Z",
+    "description": "OB Truck A cleanfeed video",
+    "label": "SRT Feed 3",
+    "format": "urn:x-nmos:format:video",
+    "created_by": "ob-truck-a",
+    "updated_by": "ob-truck-a",
+    "tags": {
+        "input_quality": "contribution",
+        "editorial_purpose": "cleanfeed"
+    },
+    "codec": "video/h264",
+    "container": "video/mp2t",
+    "avg_bit_rate": 25000,
+    "segment_duration": {
+        "numerator": 10
+    },
+    "essence_parameters": {
+        "frame_rate": {
+            "numerator": 50,
+            "denominator": 1
+        },
+        "frame_width": 1920,
+        "frame_height": 1080,
+        "bit_depth": 8,
+        "interlace_mode": "progressive",
+        "colorspace": "BT709",
+        "transfer_characteristic": "SDR",
+        "aspect_ratio": {
+            "numerator": 16,
+            "denominator": 9
+        },
+        "pixel_aspect_ratio": {
+            "numerator": 1,
+            "denominator": 1
+        },
+        "component_type": "YCbCr",
+        "vert_chroma_subs": 2,
+        "horiz_chroma_subs": 2
+    },
+    "collected_by": [
+        "e85efab4-993b-4ad6-9af3-4cd8d0d38860"
+    ]
+}

--- a/api/examples/flow-put-multi.json
+++ b/api/examples/flow-put-multi.json
@@ -9,17 +9,14 @@
     },
     "flow_collection": [
         {
-            "id": "4f79cfd1-c057-47f4-8e4d-1b126ca7bf34",
-            "priority": 1
+            "id": "4f79cfd1-c057-47f4-8e4d-1b126ca7bf34"
         },
         {
-            "id": "6101df05-06bb-41b8-8af4-cf7cd33df209",
-            "priority": 1
+            "id": "6101df05-06bb-41b8-8af4-cf7cd33df209"
         },
         {
             "id": "c8943cb3-08df-46de-8ce8-0d7d70ed204c",
-            "role": "audio_description",
-            "priority": 2
+            "role": "audio_description"
         },
         {
             "id": "e85efab4-993b-4ad6-9af3-4cd8d0d38860",

--- a/api/examples/flow-put-multi.json
+++ b/api/examples/flow-put-multi.json
@@ -10,11 +10,16 @@
     "flow_collection": [
         {
             "id": "4f79cfd1-c057-47f4-8e4d-1b126ca7bf34",
-            "role": "video"
+            "priority": 1
         },
         {
             "id": "6101df05-06bb-41b8-8af4-cf7cd33df209",
-            "role": "audio"
+            "priority": 1
+        },
+        {
+            "id": "c8943cb3-08df-46de-8ce8-0d7d70ed204c",
+            "role": "audio_description",
+            "priority": 2
         },
         {
             "id": "e85efab4-993b-4ad6-9af3-4cd8d0d38860",

--- a/api/examples/source-get-200-multi.json
+++ b/api/examples/source-get-200-multi.json
@@ -9,12 +9,10 @@
     "updated": "2008-05-27T18:51:00Z",
     "source_collection": [
         {
-            "id": "2aa143ac-0ab7-4d75-bc32-5c00c13d186f",
-            "role": "video"
+            "id": "2aa143ac-0ab7-4d75-bc32-5c00c13d186f"
         },
         {
-            "id": "7ba3fed1-3fd3-4f0e-8488-92c4ffe13838",
-            "role": "audio"
+            "id": "7ba3fed1-3fd3-4f0e-8488-92c4ffe13838"
         }
     ]
 }

--- a/api/examples/source-get-200-tags.json
+++ b/api/examples/source-get-200-tags.json
@@ -1,0 +1,16 @@
+{
+    "id": "a0456629-b25d-4c4b-b631-0861621f67c7",
+    "created": "2008-05-27T18:53:00Z",
+    "updated": "2023-09-14T09:45:26Z",
+    "description": "OB Truck A cleanfeed video",
+    "label": "SRT Feed 3",
+    "format": "urn:x-nmos:format:video",
+    "created_by": "ob-truck-a",
+    "updated_by": "ob-truck-a",
+    "tags": {
+        "editorial_purpose": "cleanfeed"
+    },
+    "collected_by": [
+        "a77d0061-0878-4e8a-a114-772d03f952c1"
+    ]
+}

--- a/api/examples/sources-get-200.json
+++ b/api/examples/sources-get-200.json
@@ -23,12 +23,10 @@
         "updated": "2008-05-27T18:51:00Z",
         "source_collection": [
             {
-                "id": "2aa143ac-0ab7-4d75-bc32-5c00c13d186f",
-                "role": "video"
+                "id": "2aa143ac-0ab7-4d75-bc32-5c00c13d186f"
             },
             {
-                "id": "7ba3fed1-3fd3-4f0e-8488-92c4ffe13838",
-                "role": "audio"
+                "id": "7ba3fed1-3fd3-4f0e-8488-92c4ffe13838"
             }
         ]
     },

--- a/api/examples/sources-get-200.json
+++ b/api/examples/sources-get-200.json
@@ -39,5 +39,21 @@
         "collected_by": [
             "86761f3a-5998-4cfe-9a89-8459bcb8ea52"
         ]
+    },
+    {
+        "id": "a0456629-b25d-4c4b-b631-0861621f67c7",
+        "created": "2008-05-27T18:53:00Z",
+        "updated": "2023-09-14T09:45:26Z",
+        "description": "OB Truck A cleanfeed video",
+        "label": "SRT Feed 3",
+        "format": "urn:x-nmos:format:video",
+        "created_by": "ob-truck-a",
+        "updated_by": "ob-truck-a",
+        "tags": {
+            "editorial_purpose": "cleanfeed"
+        },
+        "collected_by": [
+            "a77d0061-0878-4e8a-a114-772d03f952c1"
+        ]
     }
 ]

--- a/api/schemas/collection-item.json
+++ b/api/schemas/collection-item.json
@@ -16,7 +16,7 @@
             "minimum": 0
         },
         "role": {
-            "description": "An optional string describing the purpose of this element in the collection, primarily intended to be human-readable.",
+            "description": "The purpose of this element in the collection, primarily intended to be human-readable.",
             "type": "string"
         }
     }

--- a/api/schemas/collection-item.json
+++ b/api/schemas/collection-item.json
@@ -10,11 +10,6 @@
             "description": "Source or Flow Identifier of the member of this collection. Sources MUST only collect Sources, and Flows MUST only collect Flows. Must already be registered in this service instance",
             "$ref": "uuid.json"
         },
-        "priority": {
-            "description": "A number indicating the position of this element in the collection, provided to allow stable sorting in UIs and the presentation of defaults. Implementations SHOULD return results sorted by this field in ascending order, and items with no `priority` set sorted last. Where multiple elements have the same priority, their order is implementation-defined.",
-            "type": "integer",
-            "minimum": 0
-        },
         "role": {
             "description": "The purpose of this element in the collection, primarily intended to be human-readable.",
             "type": "string"

--- a/api/schemas/collection-item.json
+++ b/api/schemas/collection-item.json
@@ -3,16 +3,20 @@
     "description": "Describes how an entity (Source or Flow) is collected into another entity of the same type",
     "type": "object",
     "required": [
-        "id",
-        "role"
+        "id"
     ],
     "properties": {
         "id": {
             "description": "Source or Flow Identifier of the member of this collection. Sources MUST only collect Sources, and Flows MUST only collect Flows. Must already be registered in this service instance",
             "$ref": "uuid.json"
         },
+        "priority": {
+            "description": "A number indicating the position of this element in the collection, provided to allow stable sorting in UIs and the presentation of defaults. Implementations SHOULD return results sorted by this field in ascending order, and items with no `priority` set sorted last. Where multiple elements have the same priority, their order is implementation-defined.",
+            "type": "integer",
+            "minimum": 0
+        },
         "role": {
-            "description": "A human-readable role of the element in this collection (e.g. 'R' to denote a right audio channel in a collection of mono audio Sources)",
+            "description": "An optional string describing the purpose of this element in the collection, primarily intended to be human-readable.",
             "type": "string"
         }
     }

--- a/api/schemas/flow-collection.json
+++ b/api/schemas/flow-collection.json
@@ -1,6 +1,6 @@
 {
     "title": "Flow Collection",
-    "description": "Describes how Flows are collected into another Flow",
+    "description": "Describes how Flows are collected into another Flow. Note that this is an ordered list.",
     "type": "array",
     "items": {
         "type": "object",

--- a/docs/README.md
+++ b/docs/README.md
@@ -30,6 +30,7 @@ For more information on how we use application notes, see [here](./appnotes/READ
 | [0021](./appnotes/0021-media-integrity.md)                           | Integrity model for media in TAMS, and when interacting with other systems |
 | [0022](./appnotes/0022-transform-architectures.md)                   | Architectures for the transforming of media                     |
 | [0024](./appnotes/0024-using-init-segments.md)                       | Using Media with Initialisation Segments in TAMS                |
+| [0020](./appnotes/0025-editorial-purpose.md)                         | Editorial purpose                                               |
 
 ## ADRs
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -90,6 +90,7 @@ For more information on how we use ADRs, see [here](./adr/README.md).
 | [0047](./adr/0047-flow-profiles.md)                                | Adding Flow Profiles to TAMS                                               |
 | [0048](./adr/0048-media-integrity.md)                              | Integrity model for media in TAMS, and when interacting with other systems |
 | [0052](./adr/0052-specifying-the-sorting-of-listings.md)           | Options for specifying the sorting of listings                             |
+| [0053](./adr/0053-editorial-purpose-tag.md)                        | Editorial Purpose Tag |
 | [0054](./adr/0054-selectable-presigned-storage-urls.md)            | Support for selectable presigned storage PUT URLs                          |
 | [0055](./adr/0055-fine-grained-auth-storage-backends.md)           | Support for Fine-Grained Authorisation on Storage Backends                 |
 | [0056](./adr/0056-roles-in-collections.md)                         | Roles in Collections |

--- a/docs/README.md
+++ b/docs/README.md
@@ -92,5 +92,6 @@ For more information on how we use ADRs, see [here](./adr/README.md).
 | [0052](./adr/0052-specifying-the-sorting-of-listings.md)           | Options for specifying the sorting of listings                             |
 | [0054](./adr/0054-selectable-presigned-storage-urls.md)            | Support for selectable presigned storage PUT URLs                          |
 | [0055](./adr/0055-fine-grained-auth-storage-backends.md)           | Support for Fine-Grained Authorisation on Storage Backends                 |
+| [0056](./adr/0056-roles-in-collections.md)                         | Roles in Collections |
 
 \* Note: ADR 0004a was the unintended result of a number clash in the early development of TAMS which wasn't caught before publication

--- a/docs/adr/0053-editorial-purpose-tag.md
+++ b/docs/adr/0053-editorial-purpose-tag.md
@@ -1,5 +1,5 @@
 ---
-status: "proposed"
+status: "accepted"
 ---
 # Editorial Purpose Tag
 

--- a/docs/adr/0053-editorial-purpose-tag.md
+++ b/docs/adr/0053-editorial-purpose-tag.md
@@ -1,0 +1,88 @@
+---
+status: "proposed"
+---
+# Editorial Purpose Tag
+
+## Context and Problem Statement
+
+[ADR0056: Roles in Collections](./0056-roles-in-collections.md) concluded that `role` did not make sense for storing editorial purpose, because it's a property of the Source (and by extension Flow) itself, rather than its membership in the collection.
+This ADR considers where to store that information instead.
+
+To give some motivating examples, a Source could contain:
+
+* Programme video
+* Signed video
+* Clean-feed without graphics
+* Programme audio
+* Audio description
+* Commentary
+* Etc.
+
+## Considered Options
+
+* Option 1a: Represent editorial purpose as a field using DVB component descriptors
+* Option 1b: Represent editorial purpose as a field using roles from MPEG-DASH
+* Option 1c: Represent editorial purpose as a field based on descriptions in the MovieLabs Ontology for Media Creation
+* Option 2: Represent purpose of content using a tag
+
+## Decision Outcome
+
+Chosen option: Option 2: Represent purpose of content using a tag, because it is not clear that any particular ontology or vocabulary is appropriate in all cases, and [Principle 5: TAMS does not implement a MAM](../../PRINCIPLES.md) applies here.
+A user/content owner/broadcaster with strong opinions about how editorial purpose should be captured, should do so in a system designed for that purpose, and rely on the strong references in TAMS to cross-link the actual content.
+However the tag is useful in "MAM-less" deployments where the amount of content is small, as a hint for interoperability and to potentially aid in searching across systems.
+
+### Implementation
+
+Implemented by [AppNote 0025: Editorial Purpose](../appnotes/0025-editorial-purpose.md) in <https://github.com/bbc/tams/pull/173>.
+
+## Pros and Cons of the Options
+
+### Option 1a: Represent editorial purpose as a field using DVB component descriptors
+
+Add a new field to Flows and Sources called (for example) `editorial_purpose` that applies a controlled vocabulary drawn from DVB component descriptors.
+
+DVB uses the `stream_content`, `stream_content_ext` and `component_type` fields in the `component_descriptor` to describe the type of a Service.
+These are described in [ETSI EN 300 468 pp 60-70](https://www.etsi.org/deliver/etsi_en/300400_300499/300468/01.19.01_60/en_300468v011901p.pdf).
+TAMS could use the same descriptors, or their names.
+
+* Good, because it is part of an established standard
+* Bad, because it is not clear this aligns with the "TAMS does not implement a MAM" principle
+* Bad, because the component types are represented as hex bytes (for carriage in the SDT table) and would need human-readable names
+* Bad, because many of the types also include technical characteristics of content, making them unsuitable for use in Sources
+* Bad, because the list is focused on distribution, so cannot contain aspects such as clean-feed video
+
+### Option 1b: Represent editorial purpose as a field using MPEG-DASH roles
+
+As Option 1a, using MPEG-DASH role values instead.
+
+MPEG-DASH contains a role attribute for an `AdaptationSet`, which describes the purose of that particular track.
+A number of values for that attribute are given in the specification (see ISO/IEC 23009-1:2022 section 5.8.5.5), covering the `main` content along with others such as `alternate`, `supplementary`, `commentary`, `description`, etc.
+TAMS could use these descriptors for the table directly.
+
+* Good, because it is part of an established standard
+* Neutral, because the example use cases identified above could be represented, however some would be ambiguous, such as using `alternate` for clean-feed video
+* Bad, because it is not clear this aligns with the "TAMS does not implement a MAM" principle
+* Bad, because the list cannot be expanded beyond what is in the MPEG-DASH specification
+
+### Option 1c: Represent editorial purpose as a field based on descriptions in the MovieLabs Ontology for Media Creation
+
+As Option 1a, using values from the MovieLabs [Ontology for Media Creation](https://mc.movielabs.com/docs/ontology/).
+
+The ontology contains some definitions of the purpose of pieces of content.
+Unfortunately it does not appear to represent differing purposes of video content, and for audio it refers to definitions in SMPTE ST 377-41.
+
+* Good, because it is part of a controlled specification.
+* Bad, because it is not clear this aligns with the "TAMS does not implement a MAM" principle.
+* Bad, because video is not covered in the document.
+
+### Option 2: Represent purpose of content using a tag
+
+Add a tag along the lines of `editorial_purpose` to [AppNote 0003: Tag Names](../appnotes/0003-tag-names.md), with a list of suggested values.
+Allow new values to be added as they come up, in a similar process to other tags.
+Seed the initial list based on a combination of other specifications (including those above).
+
+* Good, because it captures suggested names without constraining the purposes that a Flow or Source can be used for.
+* Good, because inspiration can be drawn from the other documents suggested, without being constrained by them.
+* Good, because it is easy to add new items to the list.
+* Good, because tags are intended as a lightweight store of additional data for those times when, while TAMS is not a MAM, it can be a useful place to store MAM-like.
+* Bad, because the list is open-ended and uncontrolled, which may lead to content using a mix of names.

--- a/docs/adr/0053-editorial-purpose-tag.md
+++ b/docs/adr/0053-editorial-purpose-tag.md
@@ -56,7 +56,7 @@ TAMS could use the same descriptors, or their names.
 As Option 1a, using MPEG-DASH role values instead.
 
 MPEG-DASH contains a role attribute for an `AdaptationSet`, which describes the purose of that particular track.
-A number of values for that attribute are given in the specification (see ISO/IEC 23009-1:2022 section 5.8.5.5), covering the `main` content along with others such as `alternate`, `supplementary`, `commentary`, `description`, etc.
+A number of values for that attribute are given in the specification (see [ISO/IEC 23009-1:2022](https://standards.iso.org/ittf/PubliclyAvailableStandards/c083314_ISO_IEC%2023009-1_2022(en).zip) section 5.8.5.5), covering the `main` content along with others such as `alternate`, `supplementary`, `commentary`, `description`, etc.
 TAMS could use these descriptors for the table directly.
 
 * Good, because it is part of an established standard

--- a/docs/adr/0056-roles-in-collections.md
+++ b/docs/adr/0056-roles-in-collections.md
@@ -1,5 +1,5 @@
 ---
-status: proposed
+status: accepted
 ---
 # Roles in Collections
 

--- a/docs/adr/0056-roles-in-collections.md
+++ b/docs/adr/0056-roles-in-collections.md
@@ -26,10 +26,11 @@ Some better recommendations would be useful around how these cases should be han
 * Option 3: Use `role` as editorial purpose, use other queries for Flow/Source properties
 * Option 4a: Capture editorial purpose elsewhere, use `role` as an optional label
 * Option 4b: Capture editorial purpose elsewhere, use `role` as an optional label, add a `priority` for sorting
+* Option 4c: Capture editorial purpose elsewhere, use `role` as an optional label, insist list is ordered
 
 ## Decision Outcome
 
-Chosen option: Option 4b because it avoids storing properties of Flows and Sources on collection items, instead keeping them on the objects they naturally fit with.
+Chosen option: Option 4c because it avoids storing properties of Flows and Sources on collection items, instead keeping them on the objects they naturally fit with and naturally providing an ordering without additional fields.
 It also limits the changes required to the API, and while in some cases it may trigger extra API requests (e.g. to get the details of items in a collection), it is likely the details of those collection items will be needed anyway, so the requests would be needed, and was made less onerous by the additional query parameters introduced in [ADR0049](./0049-source-collected_by-query-parameter.md) (<https://github.com/bbc/tams/pull/183>).
 Furthermore the TAMS API is intended not to serve as a Media Asset Manager and provide minimal library management and discovery features: through that lens the additional request burden seems reasonable and if it becomes too onerous in a particular deployment, that may indicate a MAM is required.
 
@@ -101,4 +102,16 @@ Not being set causes sorting last.
 * Good, because it simplifies client implementations that need not worry about the "correct" value of `role`.
 * Good, because it avoids a breaking change to the specification.
 * Good, because it provides an optional stable ordering and default-selection behaviour in UIs and players.
+* Bad, because it forces clients to make additional requests to locate all the data they need.
+
+### Option 4c: Capture editorial purpose elsewhere, use `role` as an optional label, insist list is sorted
+
+As Option 4a, except indicate that collections are a sorted list and that sort order should be retained when displayed (e.g. in a UI) and for selecting defaults.
+
+* Good, because it keeps properties of the Source/Flow on that object, instead of in the collection.
+* Good, because it simplifies client implementations that need not worry about the "correct" value of `role`.
+* Good, because it avoids a breaking change to the specification.
+* Good, because it provides an optional stable ordering and default-selection behaviour in UIs and players.
+* Good, because the sort order is simple and intuitive.
+* Neutral, because service implementations must capture the sort order of the list.
 * Bad, because it forces clients to make additional requests to locate all the data they need.

--- a/docs/adr/0056-roles-in-collections.md
+++ b/docs/adr/0056-roles-in-collections.md
@@ -1,0 +1,104 @@
+---
+status: proposed
+---
+# Roles in Collections
+
+## Context and Problem Statement
+
+Each item in the collection of a multi-essence Source or Flow has a `role`, intended as a description of that item's purpose in the collection.
+Roles are intended to be human-readable, and some conventions have developed around how they get used and their values.
+However the role value is frequently used to express the editorial purpose of an item as free text, and to locate the item of interest in a collection.
+Some better recommendations would be useful around how these cases should be handled, and what values used.
+
+## Decision Drivers
+
+* Roles must be set when creating a multi-essence collection.
+* Most of the role values used or proposed are properties of the underlying Source/Flow, not its position in the collection
+* When viewing a multi-essence Source or Flow, only the list of IDs collected and roles are available: getting formats and tags requires another query.
+* As a result `role` is often used to capture that one Flow is `video` and another `audio`, but practical applications need to represent more complex packages.
+* Items in a collection serve a variety of different purposes, and it is useful to have some commonality.
+* Common selection and display conventions are useful as content is read from TAMS across multiple clients and services.
+
+## Considered Options
+
+* Option 1: Make `role` a semi-structured field containing editorial purpose, media type and other details
+* Option 2: Replace `role` with additional controlled fields
+* Option 3: Use `role` as editorial purpose, use other queries for Flow/Source properties
+* Option 4a: Capture editorial purpose elsewhere, use `role` as an optional label
+* Option 4b: Capture editorial purpose elsehwere, use `role` as an optional label, add a `priority` for sorting
+
+## Decision Outcome
+
+Chosen option: Option 4b because it avoids storing properties of Flows and Sources on collection items, instead keeping them on the objects they naturally fit with.
+It also limits the changes required to the API, and while in some cases it may trigger extra API requests (e.g. to get the details of items in a collection), it is likely the details of those collection items will be needed anyway, so the requests would be needed, and was made less onerous by the additional query parameters introduced in [ADR0049](./0049-source-collected_by-query-parameter.md) (<https://github.com/bbc/tams/pull/183>).
+Furthermore the TAMS API is intended not to serve as a Media Asset Manager and provide minimal library management and discovery features: through that lens the additional request burden seems reasonable and if it becomes too onerous in a particular deployment, that may indicate a MAM is required.
+
+One aspect that came up during consideration of `role` was how to map and represent different audio channels, which will be fully explored in a future ADR.
+
+### Implementation
+
+Implemented by <https://github.com/bbc/tams/pull/173>
+
+## Pros and Cons of the Options
+
+### Option 1: Make `role` a semi-structured field containing editorial purpose, media type and other details
+
+Write an Application Note suggesting a naming convention for the `role` field, with a structured form that captures media type, editorial purpose and additional details.
+This would be similar to the approach taken in the (now deprecated) [storage label AppNote](../appnotes/0009-storage-label-format.md).
+Clients could either read the collection items and identify both type and purpose, or query the members of the collection and consider their labels/tags directly instead.
+
+* Good, because it avoids a breaking change to the specification, instead only creating guidance.
+* Good, because it makes `role` open-ended, allowing space for future change and expansion.
+* Good, because it provides a direct path to identifying the collection member of interest.
+* Good, because it saves making additional API requests to get media type and other details of collection items.
+* Bad, because it does not constrain the use of `role`, and clients may have to rely on human intervention.
+* Bad, because it forces clients to handle and parse an un-enforced free-text field, which may be malformed as a result.
+* Bad, because it duplicates information (media type, purpose, etc.) into the `role` field of each collected item.
+
+### Option 2: Replace `role` with additional controlled fields
+
+Change the specification to remove `role` and replace it with a more precise set of fields conveying the purpose of each element in the collection.
+Some of these fields might actually be set on Flows or Sources and then the entry in the collection becomes a view into that canonical data.
+For example `editorial_purpose`, `format` and `codec` fields might be surfaced.
+
+* Good, because it constrains and precisely describes what each item in a collection is for.
+* Good, because it provides a direct path to identifying the collection member of interest.
+* Bad, because it requires a breaking change to the API, to provide a capability that can be achieved another way.
+* Bad, because the required list of fields is not clear and requires more exploration.
+* Bad, because it presents properties of Flows and Sources as properties of their position in the collection.
+
+### Option 3: Use `role` as editorial purpose, use other queries for Flow/Source properties
+
+Use `role` primarily as a label to represent the editorial purpose of an item in a collection (broadly aligned with common usage).
+Where a client needs to know more about a collection item (for example whether it is video or audio) they can request the full details from the API.
+For example if a collection contains multiple items of role "programme" the client could request all of those items by ID to find out one was video and one audio (or, subject to a draft ADR being accepted, make a direct query of `GET /flows?collected_by_id=...` and cross-reference the results with the collection listing).
+
+* Good, because it aligns with current common usage of `role`.
+* Good, because it avoids a breaking change to the specification.
+* Bad, because it forces clients to make additional requests (and possibly a somewhat complex cross-reference) to locate all the data they need.
+  In particular a UI element displaying all the Sources in a store, the editorial purposes they contain and their media types would require an additional listing request per top-level Source.
+* Bad, because it presents properties of Flows and Sources as properties of their position in the collection.
+
+### Option 4a: Capture editorial purpose elsewhere, use `role` as an optional label
+
+Add an additional field or tag to capture editorial purpose instead of the somewhat arbitrary `role` (precise details are covered in [ADR0053](./0053-editorial-purpose-tag.md)).
+Make `role` an optional field, intended solely to aid with human readability and rendering.
+Require clients to make Source/Flow listing requests for Sources/Flows collected by a given ID to find full details.
+
+* Good, because it keeps properties of the Source/Flow on that object, instead of in the collection.
+* Good, because it simplifies client implementations that need not worry about the "correct" value of `role`.
+* Good, because it avoids a breaking change to the specification.
+* Bad, because it forces clients to make additional requests to locate all the data they need.
+* Bad, because it removes the UI cue for how collections should be rendered and explored
+
+### Option 4b: Capture editorial purpose elsewhere, use `role` as an optional label, add a `priority` for sorting
+
+As Option 4a, except add an additional `priority` field defining a sort order for collection items when displayed (e.g. in a UI) and for selecting defaults.
+Lower priorities sort first, with the order of equivalent values being undefined.
+Not being set causes sorting last.
+
+* Good, because it keeps properties of the Source/Flow on that object, instead of in the collection.
+* Good, because it simplifies client implementations that need not worry about the "correct" value of `role`.
+* Good, because it avoids a breaking change to the specification.
+* Good, because it provides an optional stable ordering and default-selection behaviour in UIs and players.
+* Bad, because it forces clients to make additional requests to locate all the data they need.

--- a/docs/adr/0056-roles-in-collections.md
+++ b/docs/adr/0056-roles-in-collections.md
@@ -87,6 +87,7 @@ Make `role` an optional field, intended solely to aid with human readability and
 Require clients to make Source/Flow listing requests for Sources/Flows collected by a given ID to find full details.
 
 * Good, because it keeps properties of the Source/Flow on that object, instead of in the collection.
+* Good, because it allows editorial purpose to be captured even without the presence of a collection.
 * Good, because it simplifies client implementations that need not worry about the "correct" value of `role`.
 * Good, because it avoids a breaking change to the specification.
 * Bad, because it forces clients to make additional requests to locate all the data they need.
@@ -99,6 +100,7 @@ Lower priorities sort first, with the order of equivalent values being undefined
 Not being set causes sorting last.
 
 * Good, because it keeps properties of the Source/Flow on that object, instead of in the collection.
+* Good, because it allows editorial purpose to be captured even without the presence of a collection.
 * Good, because it simplifies client implementations that need not worry about the "correct" value of `role`.
 * Good, because it avoids a breaking change to the specification.
 * Good, because it provides an optional stable ordering and default-selection behaviour in UIs and players.
@@ -109,6 +111,7 @@ Not being set causes sorting last.
 As Option 4a, except indicate that collections are a sorted list and that sort order should be retained when displayed (e.g. in a UI) and for selecting defaults.
 
 * Good, because it keeps properties of the Source/Flow on that object, instead of in the collection.
+* Good, because it allows editorial purpose to be captured even without the presence of a collection.
 * Good, because it simplifies client implementations that need not worry about the "correct" value of `role`.
 * Good, because it avoids a breaking change to the specification.
 * Good, because it provides an optional stable ordering and default-selection behaviour in UIs and players.

--- a/docs/adr/0056-roles-in-collections.md
+++ b/docs/adr/0056-roles-in-collections.md
@@ -25,7 +25,7 @@ Some better recommendations would be useful around how these cases should be han
 * Option 2: Replace `role` with additional controlled fields
 * Option 3: Use `role` as editorial purpose, use other queries for Flow/Source properties
 * Option 4a: Capture editorial purpose elsewhere, use `role` as an optional label
-* Option 4b: Capture editorial purpose elsehwere, use `role` as an optional label, add a `priority` for sorting
+* Option 4b: Capture editorial purpose elsewhere, use `role` as an optional label, add a `priority` for sorting
 
 ## Decision Outcome
 

--- a/docs/appnotes/0003-tag-names.md
+++ b/docs/appnotes/0003-tag-names.md
@@ -86,6 +86,13 @@ Status: **Deprecated**
 Replaced by the `created` field in Flow metadata.
 Contains the ISO formatted date-time when a Flow was created.
 
+### editorial_purpose
+
+Status: **Proposed**
+
+Captures the editorial purpose of a piece of content, giving a hint about what it's for and what can be found inside.
+Values are captured in [AppNote0020 Editorial Purposes](./0020-editorial-purpose.md)
+
 ### flow_retention_offset
 
 Status: **Proposed**
@@ -275,6 +282,13 @@ Status: **Proposed**
 
 Suggested as a way to build lightweight Attribute-based Access Control in [AppNote0016: Authorisation in TAMS workflows](./0016-authorisation-in-tams-workflows.md).
 A comma separated list of auth classes used to derive permissions on the Source.
+
+### editorial_purpose
+
+Status: **Proposed**
+
+Captures the editorial purpose of a piece of content, giving a hint about what it's for and what can be found inside.
+Values are captured in [AppNote0020 Editorial Purposes](./0020-editorial-purpose.md)
 
 ### hls_exclude
 

--- a/docs/appnotes/0025-editorial-purpose.md
+++ b/docs/appnotes/0025-editorial-purpose.md
@@ -1,0 +1,33 @@
+# 0025: Editorial Purpose
+
+## Abstract
+
+An `editorial_purpose` tag is defined in [AppNote 0003: Tag Names](./0003-tag-names.md) to give a hint about what a particular Source or Flow contains and how it could be used.
+The tag's values are primarily intended to be human-readable and uncontrolled, however this list provides suggested values and their meanings to allow some commonality.
+Much like other tag definitions in TAMS, the list can be amended and will likely grow over time.
+
+## Editorial Purposes
+
+## Video
+
+| Name | Description |
+| ---- | ----------- |
+| `programme` | Primary, or default video for a piece of content, e.g. that will be edited or distributed on to the audience. |
+| `programme_signed` | Primary video with a signer in-vision. Consider using a label on the collected Source/Flow with the [language code](https://github.com/bbc/tams/blob/main/docs/appnotes/0003-tag-names.md#language_code) of the signer. |
+| `cleanfeed` | Version of the video without graphics, for reversioning and re-use. |
+
+## Audio
+
+For audio SMPTE ST377-41 provides a rich vocabulary for audio content, which can be used directly by TAMS.
+A number of common examples are reproduced here: for the full list see _Section 5.4 MCA Content_ in [ST377-41:2023](https://pub.smpte.org/doc/st377-41/): by convention TAMS uses the "MCA Content" name (rather than the Symbol value), lowercased.
+
+_Note that in general, audio Flows and Sources should also use a [language code](https://github.com/bbc/tams/blob/main/docs/appnotes/0003-tag-names.md#language_code) label to allow clients to identify the language used._
+
+| Name | Description |
+| ---- | ----------- |
+| `primary` | Primary, or default audio for a piece of content, e.g. that will be edited or distributed on to the audience. |
+| `descriptive video` | Audio description track, mixed with primary programme content for presentation to visually impaired audiences. |
+| `visually impaired` | Audio description track, not mixed with the primary programme content. |
+| `live commentary` | Commentary track, where sent separately (e.g. from a sports event).  |
+| `music and effects` | Music and Effects track, where sent separately. |
+| `audio` | In a simple A/V mux that only contains the audio and video for an asset, the `role` provides little additional information, and calling it "audio" may be sufficient. |

--- a/docs/appnotes/0025-editorial-purpose.md
+++ b/docs/appnotes/0025-editorial-purpose.md
@@ -4,7 +4,7 @@
 
 An `editorial_purpose` tag is defined in [AppNote 0003: Tag Names](./0003-tag-names.md) to give a hint about what a particular Source or Flow contains and how it could be used.
 The tag's values are primarily intended to be human-readable and uncontrolled, however this list provides suggested values and their meanings to allow some commonality.
-Much like other tag definitions in TAMS, the list can be amended and will likely grow over time.
+Much like other tag definitions in TAMS, the list can be amended and will likely grow over time: implementers may prefix an implementation-specific value along the lines of `_<service_name>_<editorial purpose>`, but should consider expanding this list.
 
 ## Editorial Purposes
 
@@ -19,15 +19,22 @@ Much like other tag definitions in TAMS, the list can be amended and will likely
 ## Audio
 
 For audio SMPTE ST377-41 provides a rich vocabulary for audio content, which can be used directly by TAMS.
-A number of common examples are reproduced here: for the full list see _Section 5.4 MCA Content_ in [ST377-41:2023](https://pub.smpte.org/doc/st377-41/): by convention TAMS uses the "MCA Content" name (rather than the Symbol value), lowercased.
+A number of common examples are reproduced here: for the full list see _Section 5.4 MCA Content_ in [ST377-41:2023](https://pub.smpte.org/doc/st377-41/): by convention TAMS uses the "MCA Content" name (rather than the Symbol value), lowercased with underscores in place of spaces.
 
 _Note that in general, audio Flows and Sources should also use a [language code](https://github.com/bbc/tams/blob/main/docs/appnotes/0003-tag-names.md#language_code) label to allow clients to identify the language used._
 
 | Name | Description |
 | ---- | ----------- |
 | `primary` | Primary, or default audio for a piece of content, e.g. that will be edited or distributed on to the audience. |
-| `descriptive video` | Audio description track, mixed with primary programme content for presentation to visually impaired audiences. |
-| `visually impaired` | Audio description track, not mixed with the primary programme content. |
-| `live commentary` | Commentary track, where sent separately (e.g. from a sports event).  |
-| `music and effects` | Music and Effects track, where sent separately. |
+| `descriptive_video` | Audio description track, mixed with primary programme content for presentation to visually impaired audiences. |
+| `visually_impaired` | Audio description track, not mixed with the primary programme content. |
+| `live_commentary` | Commentary track, where sent separately (e.g. from a sports event).  |
+| `music_and_effects` | Music and Effects track, where sent separately. |
 | `audio` | In a simple A/V mux that only contains the audio and video for an asset, the `role` provides little additional information, and calling it "audio" may be sufficient. |
+
+## Data
+
+| Name | Description |
+| ---- | ----------- |
+| `sdh` | Subtitles for the Deaf and Hard of Hearing, including descriptive information of audio cues and other non-dialogue sound |
+| `transcript` | Subtitles containing only the spoken words |

--- a/docs/appnotes/0025-editorial-purpose.md
+++ b/docs/appnotes/0025-editorial-purpose.md
@@ -37,4 +37,4 @@ _Note that in general, audio Flows and Sources should also use a [language code]
 | Name | Description |
 | ---- | ----------- |
 | `sdh` | Subtitles for the Deaf and Hard of Hearing, including descriptive information of audio cues and other non-dialogue sound |
-| `transcript` | Subtitles containing only the spoken words |
+| `transcript` | Transcript containing only the spoken words |


### PR DESCRIPTION
# Details
- Adds an ADR exploring what `role` should be used for in collections, and concluding it should become optional
- Makes the corresponding change to the API
- ...and examples
- Adds an ADR considering where to capture the "editorial purpose" of a Source or Flow (something `role` has been used for), and corresponding appnote, tags and examples

# Issue (if relevant)
GitHub Issue: Fixes #188 
Also tracked as https://jira.dev.bbc.co.uk/browse/CLOUDFIT-5509

# Related PRs
Replaces #173 since that PR had got rather messy!

# Submitter PR Checks
<!-- Tick as appropriate -->

- [X] PR completes task/fixes bug
- [ ] API version has been incremented if necessary
- [ ] ADR status has been updated, and ADR implementation has been recorded
- [X] Documentation updated (README, etc.)
- [X] PR added to Jira Issue (if relevant)
- [ ] Follow-up stories added to Jira

# Reviewer PR Checks
<!-- Tick as appropriate -->

- [ ] PR completes task/fixes bug
- [ ] Design makes sense, and fits with our current code base
- [ ] Code is easy to follow
- [ ] PR size is sensible
- [ ] Commit history is sensible and tidy

# Info on PRs
The checks above are guidelines. They don't all have to be ticked, but they should all have been considered.
