### PR TITLE
Restore container property to Multi-essence Flows

### DIFF
--- a/api/schemas/flow-multi.json
+++ b/api/schemas/flow-multi.json
@@ -2,28 +2,36 @@
     "title": "Multi-essence Flow",
     "description": "Describes a multi-essence Flow",
     "type": "object",
-    "required": [
-        "format"
-    ],
-    "properties": {
-        "format": {
-            "description": "The primary content type URN for the flow.",
-            "type": "string",
-            "enum": [
-                "urn:x-nmos:format:multi"
-            ]
+    "allOf": [
+        {
+            "$ref": "flow-technical.json"
         },
-        "essence_parameters": {
-            "title": "Multi Flow Essence Parameters",
-            "description": "Describes the parameters of the essence inside this multi Flow",
+        {
             "type": "object",
-            "additionalProperties": false,
+            "required": [
+                "format"
+            ],
             "properties": {
-                "init_segments": {
-                    "description": "Whether the Flow makes use of initialisation segments. This parameter MUST be set to `true` if Media Objects have `init_object` populated. If set to `true`, all Media Objects MUST have `init_object` populated. Assume `false` if omitted.",
-                    "type": "boolean"
+                "format": {
+                    "description": "The primary content type URN for the flow.",
+                    "type": "string",
+                    "enum": [
+                        "urn:x-nmos:format:multi"
+                    ]
+                },
+                "essence_parameters": {
+                    "title": "Multi Flow Essence Parameters",
+                    "description": "Describes the parameters of the essence inside this multi Flow",
+                    "type": "object",
+                    "additionalProperties": false,
+                    "properties": {
+                        "init_segments": {
+                            "description": "Whether the Flow makes use of initialisation segments. This parameter MUST be set to `true` if Media Objects have `init_object` populated. If set to `true`, all Media Objects MUST have `init_object` populated. Assume `false` if omitted.",
+                            "type": "boolean"
+                        }
+                    }
                 }
             }
         }
-    }
+    ]
 }


### PR DESCRIPTION
# Details
Fixes a regression introduced by #130 where `container`, `codec` etc. were inadvertently removed.

# Issue (if relevant)
GitHub Issue: #240

# Related PRs
Fixes a regression from #130 

# Submitter PR Checks
<!-- Tick as appropriate -->

- [X] PR completes task/fixes bug
- [ ] API version has been incremented if necessary
- [ ] ADR status has been updated, and ADR implementation has been recorded
- [ ] Documentation updated (README, etc.)
- [ ] PR added to Jira Issue (if relevant)
- [ ] Follow-up stories added to Jira

# Reviewer PR Checks
<!-- Tick as appropriate -->

- [ ] PR completes task/fixes bug
- [ ] Design makes sense, and fits with our current code base
- [ ] Code is easy to follow
- [ ] PR size is sensible
- [ ] Commit history is sensible and tidy

# Info on PRs
The checks above are guidelines. They don't all have to be ticked, but they should all have been considered.
