### PR TITLE
Add Flow Status Endpoints

### DIFF
--- a/api/TimeAddressableMediaStore.yaml
+++ b/api/TimeAddressableMediaStore.yaml
@@ -2267,8 +2267,7 @@ paths:
           description: ""
           content:
             application/json:
-              example: |
-                "closed_complete"
+              example: "closed_complete"
               schema:
                 $ref: schemas/flow-status.json
         "404":
@@ -2282,8 +2281,7 @@ paths:
       requestBody:
         content:
           application/json:
-            example: |
-              "closed_complete"
+            example: "closed_complete"
             schema:
               $ref: schemas/flow-status.json
         required: true

--- a/api/TimeAddressableMediaStore.yaml
+++ b/api/TimeAddressableMediaStore.yaml
@@ -2237,6 +2237,78 @@ paths:
           description: Forbidden. You do not have permission to modify this Flow. It may be marked read-only.
         "404":
           description: The requested Flow ID in the path is invalid.
+  /flows/{flowId}/status:
+    parameters:
+      - name: flowId
+        in: path
+        required: true
+        schema:
+          $ref: 'schemas/uuid.json'
+        description: The Flow identifier.
+    head:
+      summary: Flow Status
+      description: Return Flow status path headers
+      operationId: HEAD_flows-flowId-status
+      tags:
+        - Flows
+      responses:
+        "200":
+          $ref: '#/components/responses/trait_resource_info_head_200'
+        "404":
+          description: The requested Flow does not exist.
+    get:
+      summary: Flow Status
+      description: Returns the Flow status property.
+      operationId: GET_flows-flowId-status
+      tags:
+        - Flows
+      responses:
+        "200":
+          description: ""
+          content:
+            application/json:
+              example: |
+                "closed_complete"
+              schema:
+                $ref: schemas/flow-status.json
+        "404":
+          description: The requested Flow does not exist.
+    put:
+      summary: Create or Update Flow Status
+      description: Create or update the status property.
+      operationId: PUT_flows-flowId-status
+      tags:
+        - Flows
+      requestBody:
+        content:
+          application/json:
+            example: |
+              "closed_complete"
+            schema:
+              $ref: schemas/flow-status.json
+        required: true
+      responses:
+        "204":
+          description: No content. The status has been created or updated.
+        "400":
+          description: Bad request. Invalid Flow status.
+        "403":
+          description: Forbidden. You do not have permission to modify this Flow. It may be marked read-only.
+        "404":
+          description: The requested Flow does not exist.
+    delete:
+      summary: Delete Flow Status
+      description: Delete the status property.
+      operationId: DELETE_flows-flowId-status
+      tags:
+        - Flows
+      responses:
+        "204":
+          description: No content. The Flow status property has been deleted.
+        "403":
+          description: Forbidden. You do not have permission to modify this Flow. It may be marked read-only.
+        "404":
+          description: The requested Flow ID in the path is invalid.  
   /flows/{flowId}/segments:
     parameters:
       - name: flowId


### PR DESCRIPTION
# Details
This PR addresses the lack of a Flow Status endpoint. It adds a HEAD, GET, PUT and DELETE endpoint for managing the newly introduced Flow `status` property.

# Issue (if relevant)
GitHub Issue: 242

# Related PRs
none

# Submitter PR Checks
<!-- Tick as appropriate -->

- [X] PR completes task/fixes bug
- [ ] API version has been incremented if necessary
- [ ] ADR status has been updated, and ADR implementation has been recorded
- [ ] Documentation updated (README, etc.)
- [ ] PR added to Jira Issue (if relevant)
- [ ] Follow-up stories added to Jira

# Reviewer PR Checks
<!-- Tick as appropriate -->

- [ ] PR completes task/fixes bug
- [ ] Design makes sense, and fits with our current code base
- [ ] Code is easy to follow
- [ ] PR size is sensible
- [ ] Commit history is sensible and tidy

# Info on PRs
The checks above are guidelines. They don't all have to be ticked, but they should all have been considered.
